### PR TITLE
Fix #13, Remove CFE_PSP_MemSet use for addresses in RAM

### DIFF
--- a/fsw/src/hk_utils.c
+++ b/fsw/src/hk_utils.c
@@ -77,7 +77,7 @@ void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
                 DestPtr = ((uint8 *)RtTblEntry->OutputPktAddr) + CpyTblEntry->OutputOffset;
                 SrcPtr  = ((uint8 *)BufPtr) + CpyTblEntry->InputOffset;
 
-                CFE_PSP_MemCpy(DestPtr, SrcPtr, CpyTblEntry->NumBytes);
+                memcpy(DestPtr, SrcPtr, CpyTblEntry->NumBytes);
 
                 /* Set the data present field to indicate the data is there */
                 RtTblEntry->DataPresent = HK_DATA_PRESENT;

--- a/unit-test/utilities/hk_test_utils.c
+++ b/unit-test/utilities/hk_test_utils.c
@@ -180,7 +180,7 @@ void HK_Test_Setup(void)
     /* initialize test environment to default state for every test */
     UT_ResetState(0);
 
-    memset(&HK_AppData, 0, sizeof(HK_AppData_t));
+    memset(&HK_AppData, 0, sizeof(HK_AppData));
     memset(context_CFE_EVS_SendEvent, 0, sizeof(context_CFE_EVS_SendEvent));
     memset(&context_CFE_ES_WriteToSysLog, 0, sizeof(context_CFE_ES_WriteToSysLog));
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HK/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License agreement to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #13

**Testing performed**
CI

**Expected behavior changes**
None, just removes unnecessary API dependence

**System(s) tested on**
 - CI
 - Versions: Bundle main + this commit + addition of app to build

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC