### PR TITLE
Fix #24, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -120,8 +120,7 @@ void HK_AppMain(void)
     ** Exit the Application.
     */
     CFE_ES_ExitApp(HK_AppData.RunStatus);
-
-} /* End of HK_AppMain() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -212,8 +211,7 @@ int32 HK_AppInit(void)
     }
 
     return Status;
-
-} /* End of HK_AppInit() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -300,7 +298,6 @@ int32 HK_TableInit(void)
     }
 
     return CFE_SUCCESS;
-
 } /* HK_TableInit */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -320,7 +317,6 @@ void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 
     switch (CFE_SB_MsgIdToValue(MessageID))
     {
-
         case HK_SEND_COMBINED_PKT_MID:
             if (ActualLength != sizeof(HK_Send_Out_Msg_t))
             {
@@ -386,8 +382,7 @@ void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
             HK_ProcessIncomingHkData(BufPtr);
             break;
     }
-
-} /* End of HK_AppPipe() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -399,7 +394,7 @@ void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
     HK_Send_Out_Msg_t *CmdPtr = (HK_Send_Out_Msg_t *)BufPtr;
 
     HK_SendCombinedHkPacket(CmdPtr->OutMsgToSend);
-} /* end of HK_SendCombinedHKCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -408,7 +403,6 @@ void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg)
 {
-
     /* copy data into housekeeping packet */
     HK_AppData.HkPacket.CmdCounter          = HK_AppData.CmdCounter;
     HK_AppData.HkPacket.ErrCounter          = HK_AppData.ErrCounter;
@@ -419,8 +413,7 @@ void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg)
     /* Send housekeeping telemetry packet...        */
     CFE_SB_TimeStampMsg(&HK_AppData.HkPacket.TlmHeader.Msg);
     CFE_SB_TransmitMsg(&HK_AppData.HkPacket.TlmHeader.Msg, true);
-
-} /* End of HK_HousekeepingCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -429,24 +422,20 @@ void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-
     size_t ExpectedLength = sizeof(HK_NoArgCmd_t);
 
     if (HK_VerifyCmdLength(BufPtr, ExpectedLength) == HK_BAD_MSG_LENGTH_RC)
     {
-
         HK_AppData.ErrCounter++;
     }
     else
     {
-
         CFE_EVS_SendEvent(HK_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "HK No-op command, Version %d.%d.%d.%d",
                           HK_MAJOR_VERSION, HK_MINOR_VERSION, HK_REVISION, HK_MISSION_REV);
 
         HK_AppData.CmdCounter++;
     }
-
-} /* End of HK_NoopCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -459,17 +448,14 @@ void HK_ResetCtrsCmd(const CFE_SB_Buffer_t *BufPtr)
 
     if (HK_VerifyCmdLength(BufPtr, ExpectedLength) == HK_BAD_MSG_LENGTH_RC)
     {
-
         HK_AppData.ErrCounter++;
     }
     else
     {
-
         HK_ResetHkData();
         CFE_EVS_SendEvent(HK_RESET_CNTRS_CMD_EID, CFE_EVS_EventType_DEBUG, "HK Reset Counters command received");
     }
-
-} /* End of HK_ResetCtrsCmd() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -482,8 +468,7 @@ void HK_ResetHkData(void)
     HK_AppData.ErrCounter          = 0;
     HK_AppData.CombinedPacketsSent = 0;
     HK_AppData.MissingDataCtr      = 0;
-
-} /* End of HK_ResetHkData () */
+}
 
 /************************/
 /*  End of File Comment */

--- a/fsw/src/hk_app.h
+++ b/fsw/src/hk_app.h
@@ -80,7 +80,6 @@ typedef struct
     hk_runtime_tbl_entry_t *RuntimeTablePtr; /**< \brief Ptr to run-time table entry */
 
     uint8 MemPoolBuffer[HK_NUM_BYTES_IN_MEM_POOL]; /**< \brief HK mempool buffer */
-
 } HK_AppData_t;
 
 /*************************************************************************

--- a/fsw/src/hk_utils.c
+++ b/fsw/src/hk_utils.c
@@ -97,8 +97,7 @@ void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
                           "HK table definition exceeds packet length. MID:0x%08lX, Length:%d, Count:%d",
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), (int)MessageLength, (int)MessageErrors);
     }
-
-} /* end HK_ProcessIncomingHkData */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -108,8 +107,7 @@ void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
 int32 HK_ValidateHkCopyTable(void *TblPtr)
 {
     return HK_SUCCESS;
-
-} /* end HK_ValidateHkCopyTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -256,8 +254,7 @@ int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_en
     }
 
     return CFE_SUCCESS;
-
-} /* end HK_ProcessNewCopyTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -353,8 +350,7 @@ int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_e
     }
 
     return CFE_SUCCESS;
-
-} /* end HK_TearDownOldCopyTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -379,7 +375,6 @@ void HK_SendCombinedHkPacket(CFE_SB_MsgId_t WhichMidToSend)
         /* Empty table entries are defined by NULL's in this field */
         if (RtTblEntry->OutputPktAddr != NULL)
         {
-
             OutBuffer = (CFE_SB_Buffer_t *)RtTblEntry->OutputPktAddr;
             CFE_MSG_GetMsgId(&OutBuffer->Msg, &ThisEntrysOutMid);
 
@@ -418,8 +413,7 @@ void HK_SendCombinedHkPacket(CFE_SB_MsgId_t WhichMidToSend)
                           "Combined HK Packet 0x%08lX is not found in current HK Copy Table",
                           (unsigned long)CFE_SB_MsgIdToValue(WhichMidToSend));
     }
-
-} /* end HK_SendCombinedHkPacket */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -439,7 +433,7 @@ int32 HK_CheckStatusOfTables(void)
     }
 
     return HKStatus;
-} /* end HK_CheckStatusOfTables */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                     */
@@ -537,7 +531,7 @@ int32 HK_CheckStatusOfCopyTable(void)
     }
 
     return HKStatus;
-} /* end HK_CheckStatusOfCopyTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                     */
@@ -580,7 +574,7 @@ int32 HK_CheckStatusOfDumpTable(void)
     }
 
     return HKStatus;
-} /* end HK_CheckStatusOfDumpTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -616,8 +610,7 @@ int32 HK_CheckForMissingData(CFE_SB_MsgId_t OutPktToCheck, CFE_SB_MsgId_t *Missi
     } while ((Loop < HK_COPY_TABLE_ENTRIES) && (Status == HK_NO_MISSING_DATA));
 
     return Status;
-
-} /* end HK_CheckForMissingData */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -644,8 +637,7 @@ void HK_SetFlagsToNotPresent(CFE_SB_MsgId_t OutPkt)
             RtTblEntry->DataPresent = HK_DATA_NOT_PRESENT;
         }
     }
-
-} /* end HK_SetFlagsToNotPresent */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -663,7 +655,6 @@ int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
 
     if (ExpectedLength != ActualLength)
     {
-
         CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
         CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
 
@@ -676,8 +667,7 @@ int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
     }
 
     return Status;
-
-} /* End of HK_VerifyCmdLength () */
+}
 
 /************************/
 /*  End of File Comment */

--- a/fsw/tables/hk_cpy_tbl.c
+++ b/fsw/tables/hk_cpy_tbl.c
@@ -1061,7 +1061,6 @@ hk_copy_table_entry_t HK_CopyTable[HK_COPY_TABLE_ENTRIES] = {
         0,
         0,
     },
-
 };
 
 /*

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -100,7 +100,6 @@ void Test_HK_AppMain_InitFail(void)
  */
 void Test_HK_AppMain_SingleRunLoop(void)
 {
-
     /* Arrange */
     CFE_SB_MsgId_t forced_MsgID                    = HK_UT_MID_100;
     size_t         forced_MsgSize                  = 0; /* invalid message size */
@@ -1425,7 +1424,6 @@ void Test_HK_ResetHkData(void)
  */
 void UtTest_Setup(void)
 {
-
     /* Test functions for HK_AppMain */
     UtTest_Add(Test_HK_AppMain_Success, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppMain_Success");
     UtTest_Add(Test_HK_AppMain_InitFail, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppMain_InitFail");


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #24
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 