### PR TITLE
Fix #26, Apply consistent Event ID names to common events

### DIFF
--- a/docs/dox_src/cfs_hk.dox
+++ b/docs/dox_src/cfs_hk.dox
@@ -190,7 +190,7 @@
 
   If the packet length field in the
   command is set to the value expected by the HK app, then the command counter will
-  increment and a #HK_NOOP_CMD_EID event message
+  increment and a #HK_NOOP_INF_EID event message
   will be sent.  This no-op event will show the version number of the HK application.
 
   <H2>4. Sending the reset counters command</H2>

--- a/fsw/inc/hk_events.h
+++ b/fsw/inc/hk_events.h
@@ -39,7 +39,7 @@
  *  This event message is issued when the Housekeeping App completes its
  *  initialization.
  */
-#define HK_INIT_EID 1
+#define HK_INIT_INF_EID 1
 
 /**
  * \brief HK Command Code Invalid Event ID
@@ -76,7 +76,7 @@
  *  \link #HK_NOOP_CC No-op command. \endlink  The command is used primarily as an
  *  indicator that the HK application can receive commands and generate telemetry.
  */
-#define HK_NOOP_CMD_EID 4
+#define HK_NOOP_INF_EID 4
 
 /**
  * \brief HK Reset Counters Command Event ID
@@ -88,7 +88,7 @@
  *  This event message is issued when the HK application receives a Reset
  *  Counters command.
  */
-#define HK_RESET_CNTRS_CMD_EID 5
+#define HK_RESET_INF_EID 5
 
 /**
  * \brief HK Table Definition Exceeds Packet Length Event ID

--- a/fsw/inc/hk_msgdefs.h
+++ b/fsw/inc/hk_msgdefs.h
@@ -45,7 +45,7 @@
  *       Successful execution of this command may be verified with the
  *       following telemetry:
  *       - #HK_HkTlm_Payload_t.CmdCounter will increment
- *       - The #HK_NOOP_CMD_EID informational event message will be generated
+ *       - The #HK_NOOP_INF_EID informational event message will be generated
  *
  *  \par Error Conditions
  *       There are no error conditions for this command. If the Housekeeping
@@ -71,7 +71,7 @@
  *       Successful execution of this command may be verified with the
  *       following telemetry:
  *       - #HK_HkTlm_Payload_t.CmdCounter will be reset
- *       - The #HK_RESET_CNTRS_CMD_EID informational event message will
+ *       - The #HK_RESET_INF_EID informational event message will
  *         be generated
  *
  *  \par Error Conditions

--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -204,7 +204,7 @@ int32 HK_AppInit(void)
     }
 
     /* Application initialization event */
-    Status = CFE_EVS_SendEvent(HK_INIT_EID, CFE_EVS_EventType_INFORMATION, "HK Initialized.  Version %d.%d.%d.%d",
+    Status = CFE_EVS_SendEvent(HK_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "HK Initialized.  Version %d.%d.%d.%d",
                                HK_MAJOR_VERSION, HK_MINOR_VERSION, HK_REVISION, HK_MISSION_REV);
 
     if (Status != CFE_SUCCESS)
@@ -346,7 +346,7 @@ void HK_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    CFE_EVS_SendEvent(HK_NOOP_CMD_EID, CFE_EVS_EventType_INFORMATION, "HK No-op command, Version %d.%d.%d.%d",
+    CFE_EVS_SendEvent(HK_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "HK No-op command, Version %d.%d.%d.%d",
                       HK_MAJOR_VERSION, HK_MINOR_VERSION, HK_REVISION, HK_MISSION_REV);
 
     HK_AppData.CmdCounter++;
@@ -360,7 +360,7 @@ void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 void HK_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     HK_ResetHkData();
-    CFE_EVS_SendEvent(HK_RESET_CNTRS_CMD_EID, CFE_EVS_EventType_DEBUG, "HK Reset Counters command received");
+    CFE_EVS_SendEvent(HK_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "HK Reset Counters command received");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -288,7 +288,7 @@ void Test_HK_AppInit_Success(void)
 
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_INIT_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_INIT_INF_EID);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
@@ -978,7 +978,7 @@ void Test_HK_NoopCmd(void)
     /* Assert */
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_NOOP_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_NOOP_INF_EID);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
@@ -1019,7 +1019,7 @@ void Test_HK_ResetCountersCmd(void)
     /* Assert */
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_RESET_CNTRS_CMD_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_RESET_INF_EID);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #26
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt