### PR TITLE
Fix #28, Remove initializations causing Cppcheck failure

### DIFF
--- a/fsw/src/hk_utils.c
+++ b/fsw/src/hk_utils.c
@@ -54,7 +54,7 @@ void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
     uint8 *                 SrcPtr           = NULL;
     size_t                  MessageLength    = 0;
     int32                   MessageErrors    = 0;
-    int32                   LastByteAccessed = 0;
+    int32                   LastByteAccessed;
 
     CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
 
@@ -116,19 +116,19 @@ int32 HK_ValidateHkCopyTable(void *TblPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
 {
-    hk_copy_table_entry_t * StartOfCopyTable          = NULL;
-    hk_copy_table_entry_t * OuterCpyEntry             = NULL;
-    hk_copy_table_entry_t * InnerDefEntry             = NULL;
-    hk_runtime_tbl_entry_t *StartOfRtTable            = NULL;
-    hk_runtime_tbl_entry_t *OuterRtEntry              = NULL;
-    hk_runtime_tbl_entry_t *InnerRtEntry              = NULL;
-    int32                   Loop1                     = 0;
-    int32                   Loop2                     = 0;
-    CFE_SB_MsgId_t          MidOfThisPacket           = CFE_SB_INVALID_MSG_ID;
-    int32                   SizeOfThisPacket          = 0;
-    int32                   FurthestByteFromThisEntry = 0;
-    CFE_SB_Buffer_t *       NewPacketAddr             = 0;
-    int32                   Result                    = CFE_SUCCESS;
+    hk_copy_table_entry_t * StartOfCopyTable = NULL;
+    hk_copy_table_entry_t * OuterCpyEntry    = NULL;
+    hk_copy_table_entry_t * InnerDefEntry    = NULL;
+    hk_runtime_tbl_entry_t *StartOfRtTable   = NULL;
+    hk_runtime_tbl_entry_t *OuterRtEntry     = NULL;
+    hk_runtime_tbl_entry_t *InnerRtEntry     = NULL;
+    int32                   Loop1            = 0;
+    int32                   Loop2;
+    CFE_SB_MsgId_t          MidOfThisPacket;
+    int32                   SizeOfThisPacket;
+    int32                   FurthestByteFromThisEntry;
+    CFE_SB_Buffer_t *       NewPacketAddr;
+    int32                   Result;
 
     /* Ensure that the input arguments are valid */
     if (((void *)CpyTblPtr == NULL) || ((void *)RtTblPtr == NULL))
@@ -270,11 +270,11 @@ int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_e
     hk_runtime_tbl_entry_t *OuterRtEntry     = NULL;
     hk_runtime_tbl_entry_t *InnerRtEntry     = NULL;
     int32                   Loop1            = 0;
-    int32                   Loop2            = 0;
-    CFE_SB_MsgId_t          MidOfThisPacket  = CFE_SB_INVALID_MSG_ID;
-    void *                  OutputPktAddr    = NULL;
-    void *                  SavedPktAddr     = NULL;
-    int32                   Result           = CFE_SUCCESS;
+    int32                   Loop2;
+    CFE_SB_MsgId_t          MidOfThisPacket;
+    void *                  OutputPktAddr = NULL;
+    void *                  SavedPktAddr  = NULL;
+    int32                   Result;
 
     /* Ensure that the input arguments are valid */
     if (((void *)CpyTblPtr == NULL) || ((void *)RtTblPtr == NULL))


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #28 
Note: all are local variables only.
In order of the errors reported in the issue report:

In the `HK_ProcessIncomingHkData()` function:
`int32 LastByteAccessed = 0;`: `LastByteAccessed` is assigned a value on line 72, and is only used once on the line immediately after that, so the initialization at the top of the function is redundant.

In the `HK_ProcessNewCopyTable()` function:
`int32 Loop2 = 0;`: `Loop2` is used in 3 `for` loops, and it is assigned a value (of zero) each time in the init-statement. Therefore the initialization at the top of the function can safely be changed to a declaration-only.
`CFE_SB_MsgId_t MidOfThisPacket = CFE_SB_INVALID_MSG_ID;`: `MidOfThisPacket` is assigned a value on line 167 and is used twice after that in 2 loops, both of which are covered by the assignment on line 167.
`int32 SizeOfThisPacket = 0;`: `SizeOfThisPacket` is assigned a value on line 168 and is used twice after that in 2 loops, both of which are covered by the assignment on line 168.
`int32 FurthestByteFromThisEntry = 0;`: `FurthestByteFromThisEntry` is assigned a value on line 180 and is only used immediately after that in a single `if` block.
`CFE_SB_Buffer_t * NewPacketAddr = 0;`: `NewPacketAddr` is only used in the `if` block starting on line 192, and it is assigned a value (of `NULL`) immediately preceding that line, thus the initialization at the top of the function is redundant (and we can change it to a declaration-only).
`int32 Result = CFE_SUCCESS;`: The assignment to `Result` on line 194 and line 229 cover its use in the `if` blocks immediately following those assignments.

In the `HK_TearDownOldCopyTable()` function:
`int32 Loop2 = 0;`: `Loop2` is used in 2 `for` loops, and it is assigned a value (of zero) each time in the init-statement. Therefore the initialization at the top of the function can safely be changed to a declaration-only.
`CFE_SB_MsgId_t MidOfThisPacket = CFE_SB_INVALID_MSG_ID;`: `MidOfThisPacket` is only used once in this function (on line 313) and it is assigned a value preceding that use on line 301.
`int32 Result = CFE_SUCCESS;`: The assignment to `Result` on line 304 covers its use in the mutually exclusive `if`/`else` block starting on the next line, which is the only place it is used in this function.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.
Cppcheck now passes without error again.

**Contributor Info**
Avi @thnkslprpt