### PR TITLE
Fix #38, correct uninitialized variable in UT

### DIFF
--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -1231,6 +1231,8 @@ void Test_HK_HousekeepingCmd(void)
     HK_AppData.CombinedPacketsSent = 4;
     HK_AppData.MemPoolHandle       = HK_UT_MEMPOOL_1;
 
+    memset(&DummyMsg, 0, sizeof(DummyMsg));
+
     /* Act */
     HK_HousekeepingCmd(&DummyMsg);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HK/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Corrects an uninitialized variable warning - just `memset()` the object to zero.
Fixes #38

**Testing performed**
Run all unit tests

**Expected behavior changes**
No impact to behavior (called API did not dereference the pointer, so it did not matter what was in it)

**System(s) tested on**
Debian Bookworm

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
