### PR TITLE
Fix #43, Remove use of 'dummy' in test code

### DIFF
--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -922,7 +922,7 @@ void Test_HK_SendCombinedPktCmd(void)
 void Test_HK_SendHkCmd(void)
 {
     /* Arrange */
-    CFE_SB_Buffer_t     DummyMsg;
+    CFE_SB_Buffer_t     Msg;
     uint8               call_count_CFE_SB_TimeStampMsg;
     uint8               call_count_CFE_SB_TransmitMsg;
     HK_HkTlm_Payload_t *PayloadPtr;
@@ -934,10 +934,10 @@ void Test_HK_SendHkCmd(void)
     HK_AppData.CombinedPacketsSent = 4;
     HK_AppData.MemPoolHandle       = HK_UT_MEMPOOL_1;
 
-    memset(&DummyMsg, 0, sizeof(DummyMsg));
+    memset(&Msg, 0, sizeof(Msg));
 
     /* Act */
-    HK_SendHkCmd(&DummyMsg);
+    HK_SendHkCmd(&Msg);
 
     call_count_CFE_SB_TimeStampMsg = UT_GetStubCount(UT_KEY(CFE_SB_TimeStampMsg));
     call_count_CFE_SB_TransmitMsg  = UT_GetStubCount(UT_KEY(CFE_SB_TransmitMsg));
@@ -970,13 +970,13 @@ void Test_HK_SendHkCmd(void)
 void Test_HK_NoopCmd(void)
 {
     /* Arrange */
-    CFE_SB_Buffer_t DummyBuf;
+    CFE_SB_Buffer_t Buf;
     int32           strCmpResult;
     char            ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "HK No-op command, Version %%d.%%d.%%d.%%d");
 
     /* Act */
-    HK_NoopCmd(&DummyBuf);
+    HK_NoopCmd(&Buf);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1010,14 +1010,14 @@ void Test_HK_NoopCmd(void)
 void Test_HK_ResetCountersCmd(void)
 {
     /* Arrange */
-    CFE_SB_Buffer_t DummyBuf;
+    CFE_SB_Buffer_t Buf;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "HK Reset Counters command received");
 
     /* Act */
-    HK_ResetCountersCmd(&DummyBuf);
+    HK_ResetCountersCmd(&Buf);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/hk_utils_tests.c
+++ b/unit-test/hk_utils_tests.c
@@ -975,14 +975,14 @@ void Test_HK_TearDownOldCopyTable_Success2(void)
     /* Arrange */
     int32                  ReturnValue;
     int32                  i;
-    CFE_SB_Buffer_t        DummyBuffer;
+    CFE_SB_Buffer_t        Buffer;
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
 
     HK_Test_InitGoodCopyTable(CopyTblPtr);
     HK_Test_InitGoodRuntimeTable(RtTblPtr);
 
-    RtTblPtr[4].OutputPktAddr = &DummyBuffer; /* Just needs to not match the
+    RtTblPtr[4].OutputPktAddr = &Buffer; /* Just needs to not match the
                                       other filled entries */
 
     /* Act */
@@ -1147,7 +1147,7 @@ void Test_HK_SendCombinedHkPacket_PacketNotFound(void)
     CFE_SB_MsgId_t  forced_MsgID = HK_UT_MID_100; /* does not match provided parameter */
     int32           strCmpResult;
     char            ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    CFE_SB_Buffer_t DummyBuffer;
+    CFE_SB_Buffer_t Buffer;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -1156,7 +1156,7 @@ void Test_HK_SendCombinedHkPacket_PacketNotFound(void)
     HK_Test_InitEmptyRuntimeTable(RtTblPtr);
 
     /* populate one entry in the RT table */
-    RtTblPtr[1].OutputPktAddr = &DummyBuffer; /* just needs to be non-null */
+    RtTblPtr[1].OutputPktAddr = &Buffer; /* just needs to be non-null */
 
     HK_AppData.RuntimeTablePtr = RtTblPtr;
     HK_AppData.CopyTablePtr    = CopyTblPtr;
@@ -1881,11 +1881,11 @@ void Test_HK_SetFlagsToNotPresent(void)
     int32                  EntriesWithDataPresent = 0;
     hk_runtime_tbl_entry_t RtTbl[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CpyTbl[HK_COPY_TABLE_ENTRIES];
-    CFE_SB_Buffer_t        DummyBuffer;
+    CFE_SB_Buffer_t        Buffer;
     int32                  i;
     for (i = 0; i < HK_COPY_TABLE_ENTRIES; i++)
     {
-        RtTbl[i].OutputPktAddr = &DummyBuffer; /* just needs to be non-null */
+        RtTbl[i].OutputPktAddr = &Buffer; /* just needs to be non-null */
         CpyTbl[i].OutputMid    = CFE_SB_ValueToMsgId(CFE_EVS_HK_TLM_MID);
         RtTbl[i].DataPresent   = HK_DATA_PRESENT;
     }

--- a/unit-test/utilities/hk_test_utils.c
+++ b/unit-test/utilities/hk_test_utils.c
@@ -135,7 +135,7 @@ void HK_Test_InitEmptyCopyTable(hk_copy_table_entry_t *CpyTbl)
 void HK_Test_InitGoodRuntimeTable(hk_runtime_tbl_entry_t *RtTbl)
 {
     int32                   i = 0;
-    CFE_SB_Buffer_t         DummyBuffer;
+    CFE_SB_Buffer_t         Buffer;
     hk_runtime_tbl_entry_t *RtEntry = NULL;
 
     /* Loop thru the RunTime table initializing the fields */
@@ -145,7 +145,7 @@ void HK_Test_InitGoodRuntimeTable(hk_runtime_tbl_entry_t *RtTbl)
 
         if (i < 5)
         {
-            RtEntry->OutputPktAddr      = &DummyBuffer; /* just needs to be non-null */
+            RtEntry->OutputPktAddr      = &Buffer; /* just needs to be non-null */
             RtEntry->InputMidSubscribed = HK_INPUTMID_SUBSCRIBED;
             RtEntry->DataPresent        = HK_DATA_NOT_PRESENT;
         }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #43 
'Dummy' removed from test code/text. Redundant.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior. Simplifies test code.

**Contributor Info**
Avi Weiss @thnkslprpt