### PR TITLE
Fix #46, use generated stubs

### DIFF
--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 add_cfe_coverage_stubs("hk_internal"
   utilities/hk_test_utils.c
+  stubs/hk_global_stubs.c
   stubs/hk_utils_stubs.c
   stubs/hk_app_stubs.c
 )
@@ -26,13 +27,13 @@ target_include_directories(coverage-hk_internal-stubs PUBLIC ../fsw/src)
 # a *_tests file for each
 foreach(SRCFILE ${APP_SRC_FILES})
 
-    # Get the base sourcefile name as a module name without path or the  
+    # Get the base sourcefile name as a module name without path or the
     # extension, this will be used as the base name of the unit test file.
     get_filename_component(UNIT_NAME "${SRCFILE}" NAME_WE)
 
     # Use the module name to make the test name by adding _tests to the end
     set(TESTS_NAME "${UNIT_NAME}_tests")
-    
+
     # Make the test sourcefile name with unit test path and extension
     set(TESTS_SOURCE_FILE "${PROJECT_SOURCE_DIR}/unit-test/${TESTS_NAME}.c")
 

--- a/unit-test/stubs/hk_app_stubs.c
+++ b/unit-test/stubs/hk_app_stubs.c
@@ -17,69 +17,121 @@
  * limitations under the License.
  ************************************************************************/
 
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in hk_app header
+ */
+
 #include "hk_app.h"
-#include "hk_msg.h"
-#include "hk_events.h"
-#include "hk_version.h"
-#include "hk_msgids.h"
-#include "hk_utils.h"
+#include "utgenstub.h"
 
-#include <string.h>
-
-/* UT includes */
-#include "uttest.h"
-#include "utassert.h"
-#include "utstubs.h"
-
-HK_AppData_t HK_AppData;
-
-void HK_AppMain(void)
-{
-    UtPrintf("HK_AppMain Stub");
-    UT_DEFAULT_IMPL(HK_AppMain);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_AppInit()
+ * ----------------------------------------------------
+ */
 int32 HK_AppInit(void)
 {
-    return UT_DEFAULT_IMPL(HK_AppInit);
+    UT_GenStub_SetupReturnBuffer(HK_AppInit, int32);
+
+    UT_GenStub_Execute(HK_AppInit, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_AppInit, int32);
 }
 
-int32 HK_TableInit(void)
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_AppMain()
+ * ----------------------------------------------------
+ */
+void HK_AppMain(void)
 {
-    return UT_DEFAULT_IMPL(HK_TableInit);
+
+    UT_GenStub_Execute(HK_AppMain, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_AppPipe()
+ * ----------------------------------------------------
+ */
 void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(HK_AppPipe), BufPtr);
-    UT_DEFAULT_IMPL(HK_AppPipe);
+    UT_GenStub_AddParam(HK_AppPipe, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_AppPipe, Basic, NULL);
 }
 
-void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContext(UT_KEY(HK_SendCombinedHKCmd), BufPtr);
-    UT_DEFAULT_IMPL(HK_SendCombinedHKCmd);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_HousekeepingCmd()
+ * ----------------------------------------------------
+ */
 void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg)
 {
-    UT_Stub_RegisterContext(UT_KEY(HK_HousekeepingCmd), Msg);
-    UT_DEFAULT_IMPL(HK_HousekeepingCmd);
+    UT_GenStub_AddParam(HK_HousekeepingCmd, const CFE_MSG_CommandHeader_t *, Msg);
+
+    UT_GenStub_Execute(HK_HousekeepingCmd, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_NoopCmd()
+ * ----------------------------------------------------
+ */
 void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(HK_NoopCmd), BufPtr);
-    UT_DEFAULT_IMPL(HK_NoopCmd);
+    UT_GenStub_AddParam(HK_NoopCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_NoopCmd, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_ResetCtrsCmd()
+ * ----------------------------------------------------
+ */
 void HK_ResetCtrsCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(HK_ResetCtrsCmd), BufPtr);
-    UT_DEFAULT_IMPL(HK_ResetCtrsCmd);
+    UT_GenStub_AddParam(HK_ResetCtrsCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_ResetCtrsCmd, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_ResetHkData()
+ * ----------------------------------------------------
+ */
 void HK_ResetHkData(void)
 {
-    UT_DEFAULT_IMPL(HK_ResetHkData);
+
+    UT_GenStub_Execute(HK_ResetHkData, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_SendCombinedHKCmd()
+ * ----------------------------------------------------
+ */
+void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HK_SendCombinedHKCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_SendCombinedHKCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_TableInit()
+ * ----------------------------------------------------
+ */
+int32 HK_TableInit(void)
+{
+    UT_GenStub_SetupReturnBuffer(HK_TableInit, int32);
+
+    UT_GenStub_Execute(HK_TableInit, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_TableInit, int32);
 }

--- a/unit-test/stubs/hk_global_stubs.c
+++ b/unit-test/stubs/hk_global_stubs.c
@@ -1,0 +1,27 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,919-1, and identified as “Core Flight
+ * System (cFS) Housekeeping (HK) Application version 2.5.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+#include "hk_app.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+HK_AppData_t HK_AppData;

--- a/unit-test/stubs/hk_utils_stubs.c
+++ b/unit-test/stubs/hk_utils_stubs.c
@@ -17,73 +17,173 @@
  * limitations under the License.
  ************************************************************************/
 
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in hk_utils header
+ */
+
 #include "hk_utils.h"
-#include "uttest.h"
-#include "utstubs.h"
+#include "utgenstub.h"
 
-void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_Stub_RegisterContext(UT_KEY(HK_ProcessIncomingHkData), BufPtr);
-    UT_DEFAULT_IMPL(HK_ProcessIncomingHkData);
-}
-
-int32 HK_ValidateHkCopyTable(void *TblPtr)
-{
-    UT_Stub_RegisterContext(UT_KEY(HK_ValidateHkCopyTable), TblPtr);
-    return UT_DEFAULT_IMPL(HK_ValidateHkCopyTable);
-}
-
-int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
-{
-    UT_Stub_RegisterContext(UT_KEY(HK_ProcessNewCopyTable), CpyTblPtr);
-    UT_Stub_RegisterContext(UT_KEY(HK_ProcessNewCopyTable), RtTblPtr);
-    return UT_DEFAULT_IMPL(HK_ProcessNewCopyTable);
-}
-
-int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
-{
-    UT_Stub_RegisterContext(UT_KEY(HK_TearDownOldCopyTable), CpyTblPtr);
-    UT_Stub_RegisterContext(UT_KEY(HK_TearDownOldCopyTable), RtTblPtr);
-    return UT_DEFAULT_IMPL(HK_TearDownOldCopyTable);
-}
-
-void HK_SendCombinedHkPacket(CFE_SB_MsgId_t WhichMidToSend)
-{
-    UT_Stub_RegisterContextGenericArg(UT_KEY(HK_SendCombinedHkPacket), WhichMidToSend);
-    UT_DEFAULT_IMPL(HK_SendCombinedHkPacket);
-}
-
-int32 HK_CheckStatusOfTables(void)
-{
-    return UT_DEFAULT_IMPL(HK_CheckStatusOfTables);
-}
-
-int32 HK_CheckStatusOfCopyTable(void)
-{
-    return UT_DEFAULT_IMPL(HK_CheckStatusOfCopyTable);
-}
-
-int32 HK_CheckStatusOfDumpTable(void)
-{
-    return UT_DEFAULT_IMPL(HK_CheckStatusOfDumpTable);
-}
-
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_CheckForMissingData()
+ * ----------------------------------------------------
+ */
 int32 HK_CheckForMissingData(CFE_SB_MsgId_t OutPktToCheck, CFE_SB_MsgId_t *MissingInputMid)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(HK_CheckForMissingData), OutPktToCheck);
-    UT_Stub_RegisterContext(UT_KEY(HK_CheckForMissingData), MissingInputMid);
-    return UT_DEFAULT_IMPL(HK_CheckForMissingData);
+    UT_GenStub_SetupReturnBuffer(HK_CheckForMissingData, int32);
+
+    UT_GenStub_AddParam(HK_CheckForMissingData, CFE_SB_MsgId_t, OutPktToCheck);
+    UT_GenStub_AddParam(HK_CheckForMissingData, CFE_SB_MsgId_t *, MissingInputMid);
+
+    UT_GenStub_Execute(HK_CheckForMissingData, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_CheckForMissingData, int32);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_CheckStatusOfCopyTable()
+ * ----------------------------------------------------
+ */
+int32 HK_CheckStatusOfCopyTable(void)
+{
+    UT_GenStub_SetupReturnBuffer(HK_CheckStatusOfCopyTable, int32);
+
+    UT_GenStub_Execute(HK_CheckStatusOfCopyTable, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_CheckStatusOfCopyTable, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_CheckStatusOfDumpTable()
+ * ----------------------------------------------------
+ */
+int32 HK_CheckStatusOfDumpTable(void)
+{
+    UT_GenStub_SetupReturnBuffer(HK_CheckStatusOfDumpTable, int32);
+
+    UT_GenStub_Execute(HK_CheckStatusOfDumpTable, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_CheckStatusOfDumpTable, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_CheckStatusOfTables()
+ * ----------------------------------------------------
+ */
+int32 HK_CheckStatusOfTables(void)
+{
+    UT_GenStub_SetupReturnBuffer(HK_CheckStatusOfTables, int32);
+
+    UT_GenStub_Execute(HK_CheckStatusOfTables, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_CheckStatusOfTables, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_ProcessIncomingHkData()
+ * ----------------------------------------------------
+ */
+void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HK_ProcessIncomingHkData, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_ProcessIncomingHkData, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_ProcessNewCopyTable()
+ * ----------------------------------------------------
+ */
+int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
+{
+    UT_GenStub_SetupReturnBuffer(HK_ProcessNewCopyTable, int32);
+
+    UT_GenStub_AddParam(HK_ProcessNewCopyTable, hk_copy_table_entry_t *, CpyTblPtr);
+    UT_GenStub_AddParam(HK_ProcessNewCopyTable, hk_runtime_tbl_entry_t *, RtTblPtr);
+
+    UT_GenStub_Execute(HK_ProcessNewCopyTable, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_ProcessNewCopyTable, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_SendCombinedHkPacket()
+ * ----------------------------------------------------
+ */
+void HK_SendCombinedHkPacket(CFE_SB_MsgId_t WhichMidToSend)
+{
+    UT_GenStub_AddParam(HK_SendCombinedHkPacket, CFE_SB_MsgId_t, WhichMidToSend);
+
+    UT_GenStub_Execute(HK_SendCombinedHkPacket, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_SetFlagsToNotPresent()
+ * ----------------------------------------------------
+ */
 void HK_SetFlagsToNotPresent(CFE_SB_MsgId_t OutPkt)
 {
-    UT_Stub_RegisterContextGenericArg(UT_KEY(HK_SetFlagsToNotPresent), OutPkt);
-    UT_DEFAULT_IMPL(HK_SetFlagsToNotPresent);
+    UT_GenStub_AddParam(HK_SetFlagsToNotPresent, CFE_SB_MsgId_t, OutPkt);
+
+    UT_GenStub_Execute(HK_SetFlagsToNotPresent, Basic, NULL);
 }
 
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_TearDownOldCopyTable()
+ * ----------------------------------------------------
+ */
+int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
+{
+    UT_GenStub_SetupReturnBuffer(HK_TearDownOldCopyTable, int32);
+
+    UT_GenStub_AddParam(HK_TearDownOldCopyTable, hk_copy_table_entry_t *, CpyTblPtr);
+    UT_GenStub_AddParam(HK_TearDownOldCopyTable, hk_runtime_tbl_entry_t *, RtTblPtr);
+
+    UT_GenStub_Execute(HK_TearDownOldCopyTable, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_TearDownOldCopyTable, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_ValidateHkCopyTable()
+ * ----------------------------------------------------
+ */
+int32 HK_ValidateHkCopyTable(void *TblPtr)
+{
+    UT_GenStub_SetupReturnBuffer(HK_ValidateHkCopyTable, int32);
+
+    UT_GenStub_AddParam(HK_ValidateHkCopyTable, void *, TblPtr);
+
+    UT_GenStub_Execute(HK_ValidateHkCopyTable, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_ValidateHkCopyTable, int32);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_VerifyCmdLength()
+ * ----------------------------------------------------
+ */
 int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
 {
-    UT_Stub_RegisterContext(UT_KEY(HK_VerifyCmdLength), BufPtr);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(HK_VerifyCmdLength), ExpectedLength);
-    return UT_DEFAULT_IMPL(HK_VerifyCmdLength);
+    UT_GenStub_SetupReturnBuffer(HK_VerifyCmdLength, int32);
+
+    UT_GenStub_AddParam(HK_VerifyCmdLength, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(HK_VerifyCmdLength, size_t, ExpectedLength);
+
+    UT_GenStub_Execute(HK_VerifyCmdLength, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_VerifyCmdLength, int32);
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HK/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Separate the global variables into separate stub source units, then re-run the stub generator for all internal APIs. The committed result here is the exact output of the tool, unmodified.

This eases future maintenance, when an internal API changes one just needs to re-run the stub generator tool to update it

Fixes #46

**Testing performed**
Build and run all tests.  (Affects UT only)

**Expected behavior changes**
Stubs easier to maintain going forward.  No changes in behavior.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
