### PR TITLE
Fix #42, use payload structure

### DIFF
--- a/docs/dox_src/cfs_hk.dox
+++ b/docs/dox_src/cfs_hk.dox
@@ -199,11 +199,11 @@
     
   <H2>5. Monitoring the command counter</H2>
    
-  The #HK_HkPacket_t.CmdCounter will increment only 
+  The #HK_HkTlm_Payload_t.CmdCounter will increment only 
   when the HK application receives a valid #HK_NOOP_CC.
 
   <H2>6. Monitoring the command error counter</H2>
-  The #HK_HkPacket_t.ErrCounter will increment under the following conditions:
+  The #HK_HkTlm_Payload_t.ErrCounter will increment under the following conditions:
       a. Invalid command code
       b. Unexpected packet length field for #HK_SEND_COMBINED_PKT_MID command
       c. Unexpected packet length field for #HK_SEND_HK_MID command
@@ -213,7 +213,7 @@
   <H2>7. Monitoring the 'Combined Packets Sent" counter</H2>
   
   Each time a #HK_SEND_COMBINED_PKT_MID \copybrief HK_SEND_COMBINED_PKT_MID is 
-  received without error #HK_HkPacket_t.CombinedPacketsSent will increment.
+  received without error #HK_HkTlm_Payload_t.CombinedPacketsSent will increment.
 
   <H2>8. Monitoring the 'Missing Data" counter</H2>
   
@@ -221,12 +221,12 @@
   received without error, the HK app begins checking the 'Data Present' flag (located 
   in the run-time table) for each of the data sections that make up the output packet. 
   If a data portion is missing, HK sends a debug event (which is filtered by default) 
-  and increments #HK_HkPacket_t.MissingDataCtr.
+  and increments #HK_HkTlm_Payload_t.MissingDataCtr.
   The event will display the Message ID of the input message that would normally 
   provide the missing portion.
   
   <B>NOTE:</B> HK will report only one missing data portion in any output message. 
-  The #HK_HkPacket_t.MissingDataCtr will advance 
+  The #HK_HkTlm_Payload_t.MissingDataCtr will advance 
   by one count (at most) and send one event (at most) for each 
   #HK_SEND_COMBINED_PKT_MID.
    
@@ -238,7 +238,7 @@
   The HK memory pool is used to allocate the memory needed to store the output
   packets. Each time a new copy table is processed, the memory for the output
   packets is dynamically allocated from the memory pool. The memory pool handle is
-  sent down in #HK_HkPacket_t. 
+  sent down in #HK_HkTlm_Payload_t. 
   It is possible to get statistics from the cFE ES application on the memory pool 
   used by this application. #CFE_ES_SEND_MEM_POOL_STATS_CC is
   used to get statistics will need this memory pool handle as a command parameter.

--- a/fsw/inc/hk_msg.h
+++ b/fsw/inc/hk_msg.h
@@ -32,16 +32,24 @@
  */
 
 /**
- *  \brief Send Combined Output Message Command
+ *  \brief Send Combined Output Payload
  *
  *  This structure contains the format of the command used to inform HK to send
  *  the specified combined output message
  */
 typedef struct
 {
+    CFE_SB_MsgId_t OutMsgToSend; /**< \brief MsgId of combined tlm pkt to send  */
+} HK_SendCombinedPkt_Payload_t;
+
+/**
+ *  \brief Send Combined Output Message Command
+ */
+typedef struct
+{
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command Message Header */
 
-    CFE_SB_MsgId_t OutMsgToSend; /**< \brief MsgId of combined tlm pkt to send  */
+    HK_SendCombinedPkt_Payload_t Payload;
 } HK_SendCombinedPktCmd_t;
 
 /**
@@ -80,18 +88,26 @@ typedef struct
  */
 
 /**
- *  \brief HK Application housekeeping Packet
+ *  \brief HK Application housekeeping Payload
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Message Header */
-
     uint8              CmdCounter;          /**< \brief Count of valid commands received */
     uint8              ErrCounter;          /**< \brief Count of invalid commands received */
     uint16             Padding;             /**< \brief Padding to force 32 bit alignment */
     uint16             CombinedPacketsSent; /**< \brief Count of combined tlm pkts sent */
     uint16             MissingDataCtr;      /**< \brief Number of times missing data was detected */
     CFE_ES_MemHandle_t MemPoolHandle;       /**< \brief Memory pool handle used to get mempool diags */
+} HK_HkTlm_Payload_t;
+
+/**
+ *  \brief HK Application housekeeping Packet
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry Message Header */
+
+    HK_HkTlm_Payload_t Payload;
 } HK_HkPacket_t;
 
 /**\}*/

--- a/fsw/inc/hk_msgdefs.h
+++ b/fsw/inc/hk_msgdefs.h
@@ -44,7 +44,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with the
  *       following telemetry:
- *       - #HK_HkPacket_t.CmdCounter will increment
+ *       - #HK_HkTlm_Payload_t.CmdCounter will increment
  *       - The #HK_NOOP_CMD_EID informational event message will be generated
  *
  *  \par Error Conditions
@@ -70,7 +70,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with the
  *       following telemetry:
- *       - #HK_HkPacket_t.CmdCounter will be reset
+ *       - #HK_HkTlm_Payload_t.CmdCounter will be reset
  *       - The #HK_RESET_CNTRS_CMD_EID informational event message will
  *         be generated
  *

--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -392,9 +392,9 @@ void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    const HK_SendCombinedPktCmd_t *CmdPtr;
+    const HK_SendCombinedPkt_Payload_t *CmdPtr;
 
-    CmdPtr = (const HK_SendCombinedPktCmd_t *)BufPtr;
+    CmdPtr = &((const HK_SendCombinedPktCmd_t *)BufPtr)->Payload;
 
     HK_SendCombinedHkPacket(CmdPtr->OutMsgToSend);
 }
@@ -406,12 +406,16 @@ void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg)
 {
+    HK_HkTlm_Payload_t *PayloadPtr;
+
+    PayloadPtr = &HK_AppData.HkPacket.Payload;
+
     /* copy data into housekeeping packet */
-    HK_AppData.HkPacket.CmdCounter          = HK_AppData.CmdCounter;
-    HK_AppData.HkPacket.ErrCounter          = HK_AppData.ErrCounter;
-    HK_AppData.HkPacket.MissingDataCtr      = HK_AppData.MissingDataCtr;
-    HK_AppData.HkPacket.CombinedPacketsSent = HK_AppData.CombinedPacketsSent;
-    HK_AppData.HkPacket.MemPoolHandle       = HK_AppData.MemPoolHandle;
+    PayloadPtr->CmdCounter          = HK_AppData.CmdCounter;
+    PayloadPtr->ErrCounter          = HK_AppData.ErrCounter;
+    PayloadPtr->MissingDataCtr      = HK_AppData.MissingDataCtr;
+    PayloadPtr->CombinedPacketsSent = HK_AppData.CombinedPacketsSent;
+    PayloadPtr->MemPoolHandle       = HK_AppData.MemPoolHandle;
 
     /* Send housekeeping telemetry packet...        */
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(HK_AppData.HkPacket.TelemetryHeader));

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -1223,6 +1223,7 @@ void Test_HK_HousekeepingCmd(void)
     CFE_MSG_CommandHeader_t DummyMsg;
     uint8                   call_count_CFE_SB_TimeStampMsg;
     uint8                   call_count_CFE_SB_TransmitMsg;
+    HK_HkTlm_Payload_t *    PayloadPtr;
 
     /* Setup app data values */
     HK_AppData.CmdCounter          = 1;
@@ -1240,12 +1241,13 @@ void Test_HK_HousekeepingCmd(void)
     call_count_CFE_SB_TransmitMsg  = UT_GetStubCount(UT_KEY(CFE_SB_TransmitMsg));
 
     /* Assert */
-    UtAssert_INT32_EQ(HK_AppData.CmdCounter, HK_AppData.HkPacket.CmdCounter);
-    UtAssert_INT32_EQ(HK_AppData.ErrCounter, HK_AppData.HkPacket.ErrCounter);
-    UtAssert_INT32_EQ(HK_AppData.MissingDataCtr, HK_AppData.HkPacket.MissingDataCtr);
-    UtAssert_INT32_EQ(HK_AppData.CombinedPacketsSent, HK_AppData.HkPacket.CombinedPacketsSent);
-    UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(HK_AppData.MemPoolHandle, HK_AppData.HkPacket.MemPoolHandle),
-                  "CFE_RESOURCEID_TEST_EQUAL(HK_AppData.MemPoolHandle, HK_AppData.HkPacket.MemPoolHandle)");
+    PayloadPtr = &HK_AppData.HkPacket.Payload;
+    UtAssert_INT32_EQ(HK_AppData.CmdCounter, PayloadPtr->CmdCounter);
+    UtAssert_INT32_EQ(HK_AppData.ErrCounter, PayloadPtr->ErrCounter);
+    UtAssert_INT32_EQ(HK_AppData.MissingDataCtr, PayloadPtr->MissingDataCtr);
+    UtAssert_INT32_EQ(HK_AppData.CombinedPacketsSent, PayloadPtr->CombinedPacketsSent);
+    UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(HK_AppData.MemPoolHandle, PayloadPtr->MemPoolHandle),
+                  "CFE_RESOURCEID_TEST_EQUAL(HK_AppData.MemPoolHandle, PayloadPtr->MemPoolHandle)");
 
     UtAssert_INT32_EQ(call_count_CFE_SB_TimeStampMsg, 1);
     UtAssert_INT32_EQ(call_count_CFE_SB_TransmitMsg, 1);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Puts the CMD/TLM content in a member struct called "Payload".  This makes it consistent with other CFE modules and provides a predictably named member for determining the position of non-header content.

Fixes #42

**Testing performed**
Build and run all tests, sanity check app in CFE

**Expected behavior changes**
None.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
