### PR TITLE
Fix #45, use separate dispatcher for messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ project(CFS_HK C)
 
 set(APP_SRC_FILES
   fsw/src/hk_app.c
+  fsw/src/hk_dispatch.c
   fsw/src/hk_utils.c
 )
 

--- a/docs/dox_src/cfs_hk.dox
+++ b/docs/dox_src/cfs_hk.dox
@@ -53,11 +53,11 @@
   <H2> Scope </H2>
 
   This document provides a complete specification for the commands and telemetry associated
-  with the CFS Housekeeping (HK) application software.  The document is intended primarily 
-  for users of the software (operations personal, test engineers, and maintenance personnel).  
-  The last section of the document, the deployment guide section, is intended for mission 
-  developers when deploying and configuring the FM application software for a mission 
-  flight software build environment. 
+  with the CFS Housekeeping (HK) application software.  The document is intended primarily
+  for users of the software (operations personal, test engineers, and maintenance personnel).
+  The last section of the document, the deployment guide section, is intended for mission
+  developers when deploying and configuring the FM application software for a mission
+  flight software build environment.
 
   \ref cfshkversion
 
@@ -121,16 +121,16 @@
   The HK Application is a passive application and is completely packet driven.
   There are no timers used to wake up the application. The housekeeping request
   commands are not sent to the system apps by HK. A common system design uses the
-  Scheduler (SCH) Application to send the housekeeping 
+  Scheduler (SCH) Application to send the housekeeping
   requests to the system apps as well as the send-output-message-x command to HK.
 
-  A key component that is part of the HK application is the 'copy table'. The copy 
+  A key component that is part of the HK application is the 'copy table'. The copy
   table has a configurable number of entries. Each entry specifies a source (via
-  msgid and offset into the packet), destination (via msgid and offset) and a 
+  msgid and offset into the packet), destination (via msgid and offset) and a
   number of bytes to copy.
 
   <H2> HK Design Overview </H2>
-  
+
   The HK Application has a single Software Bus pipe and wakes
   up only when a message is received on the pipe (named HK_CMD_PIPE). The
   HK_CMD_PIPE receives commands and input messages. If the message received
@@ -144,10 +144,10 @@
   than one area in the same output packet. The number of output packets is also
   limited only by the the number of entries in the table. The number of entries in
   the table is a platform configuration parameter.
-  
-  The output messages are sent to the software bus when HK receives the 
-  'Send Output Message x' command. Where 'x' is a parameter in the command that 
-  specifies the message ID of the output message to send. If a piece of data is 
+
+  The output messages are sent to the software bus when HK receives the
+  'Send Output Message x' command. Where 'x' is a parameter in the command that
+  specifies the message ID of the output message to send. If a piece of data is
   missing in the output message at the time the 'Send Output Message x' command
   is received, the HK app will send a debug event (which is filtered by default)
   and increment the 'missing data counter' in telemetry.
@@ -158,45 +158,45 @@
 
   The operational interface of the HK application consists of two commands, two
   tables and a few telemetry points. The following items detail the operational
-  interface. 
+  interface.
 
   <H2>1. The application version number</H2>
-  
+
   The application version number is displayed in the initialization event and the
   no-op event. Both events are 'informational' type and are unfiltered by default.
 
   <H2>2. Loading the copy table</H2>
-  
+
   The copy table is loaded by way of a file. The file must be present when the
   application starts up. Otherwise, the app will terminate after initialization.
   The location of the file is specified by the platform configuration parameter
-  named #HK_COPY_TABLE_FILENAME. The value of this define specifies the full  
+  named #HK_COPY_TABLE_FILENAME. The value of this define specifies the full
   path as well as the filename.
-  
-  After initialization, a new copy table may be loaded at any time. The steps to 
+
+  After initialization, a new copy table may be loaded at any time. The steps to
   load a new copy table are:
       - Transfer the table file to the on-board file system
       - Send the #CFE_TBL_LOAD_CC \copybrief CFE_TBL_LOAD_CC
       - Send the #CFE_TBL_VALIDATE_CC \copybrief CFE_TBL_VALIDATE_CC
       - Send the #CFE_TBL_ACTIVATE_CC \copybrief CFE_TBL_ACTIVATE_CC
-      
+
   The HK application will clean up the items used for the old table (such as SB
   subscriptions) before updating and processing the new table.
 
   <H2>3. Sending the No-op Command</H2>
-  
+
   To verify connectivity with the Housekeeping application, the ground may send an
   #HK_NOOP_CC \copybrief HK_NOOP_CC
 
-  If the packet length field in the 
-  command is set to the value expected by the HK app, then the command counter will 
+  If the packet length field in the
+  command is set to the value expected by the HK app, then the command counter will
   increment and a #HK_NOOP_CMD_EID event message
   will be sent.  This no-op event will show the version number of the HK application.
-    
+
   <H2>4. Sending the reset counters command</H2>
-  
-  The #HK_RESET_CC \copybrief HK_RESET_CC will reset counters in telemetry.
-    
+
+  The #HK_RESET_COUNTERS_CC \copybrief HK_RESET_COUNTERS_CC will reset counters in telemetry.
+
   <H2>5. Monitoring the command counter</H2>
    
   The #HK_HkTlm_Payload_t.CmdCounter will increment only 
@@ -208,7 +208,7 @@
       b. Unexpected packet length field for #HK_SEND_COMBINED_PKT_MID command
       c. Unexpected packet length field for #HK_SEND_HK_MID command
       d. Unexpected packet length field for #HK_NOOP_CC command
-      e. Unexpected packet length field for #HK_RESET_CC command
+      e. Unexpected packet length field for #HK_RESET_COUNTERS_CC command
 
   <H2>7. Monitoring the 'Combined Packets Sent" counter</H2>
   
@@ -229,12 +229,12 @@
   The #HK_HkTlm_Payload_t.MissingDataCtr will advance 
   by one count (at most) and send one event (at most) for each 
   #HK_SEND_COMBINED_PKT_MID.
-   
+
   The HK app will not zero-out or alter the missing data section(s) in any way.
   The missing data values will match the last 'good' section received.
 
   <H2>9. Using the Memory Pool handle to get mempool stats</H2>
-  
+
   The HK memory pool is used to allocate the memory needed to store the output
   packets. Each time a new copy table is processed, the memory for the output
   packets is dynamically allocated from the memory pool. The memory pool handle is
@@ -248,22 +248,22 @@
   \page cfshkdg CFS Housekeeping Deployment Guide
 
   Follow the general guidelines below for platform deployment of the Housekeeping app.
-  
+
   There are two message IDs that must be included in the CFS Scheduler Table:
   #HK_SEND_HK_MID is sent out at the housekeeping request interval.  The housekeeping app must send its
   housekeeping data to itself like any other app.
   #HK_SEND_COMBINED_PKT_MID is sent out at the desired rate for each combined packet.  UP to four
   combined packets are available.
-  
+
   The HK app can build up to four combined packets based on the definitions supplied in the
-  HK copy table.  The Scheduler Table uses each telemetry IDs (#HK_COMBINED_PKT1_MID , 
+  HK copy table.  The Scheduler Table uses each telemetry IDs (#HK_COMBINED_PKT1_MID ,
   #HK_COMBINED_PKT2_MID , #HK_COMBINED_PKT3_MID , and #HK_COMBINED_PKT4_MID ) as a valid parameter
   in the #HK_SEND_COMBINED_PKT_MID table entries.
-  
+
   The ES app uses the HK performance ID, #HK_APPMAIN_PERF_ID , to keep track of the performance
   of the HK app.
-  
-  The platform configuration file hk_platform_cfg.h contains parameters that can be adjusted to 
+
+  The platform configuration file hk_platform_cfg.h contains parameters that can be adjusted to
   specific platforms.  See \ref cfshkplatformcfg.
 
   See \ref cfshkmissioncfg for mission configuration parameters.
@@ -271,7 +271,7 @@
 
 /**
   \page cfshktbl CFS Housekeeping Table Definitions
-  
+
   The Housekeeping Application uses two tables. A load-dump table referred to as
   the "copy table" and a dump-only table referred to as the "run-time table". Each
   table has the same number of entries, defined by the configuration parameter
@@ -281,12 +281,12 @@
   tables were chosen so that checksumming can be executed on the more-static copy
   table.
 
-  <B>HK Copy Table Validation</B> - The HK copy table currently has an empty validation 
-  call-back function that always returns success. At the time of development, 
+  <B>HK Copy Table Validation</B> - The HK copy table currently has an empty validation
+  call-back function that always returns success. At the time of development,
   a validation process that would apply to all projects was not perceived.
 
   <B>HK Copy Table Entries</B> - Entries follow the concept of:
-  <I>Copy A bytes from input message B, byte-offset C to output message Y, 
+  <I>Copy A bytes from input message B, byte-offset C to output message Y,
   byte-offset Z. </I>
 
   The structure format of a single copy table entry is defined by #hk_copy_table_entry_t.
@@ -309,7 +309,7 @@
 /**
   \page cfshkcons CFS Housekeeping Constraints
 
-  The Housekeeping Application needs to find a valid table at the location 
+  The Housekeeping Application needs to find a valid table at the location
   specified by the configuration parameter #HK_COPY_TABLE_FILENAME in order to
   startup. Otherwise the application will send an error event or syslog message
   then terminate. See \ref cfshktbl for more detail.
@@ -323,10 +323,10 @@
   \page cfshkfaqs CFS Housekeeping Frequently Asked Questions
 
   <B> (Q)
-     Does the protocol for collecting telemetry use a single housekeeping request 
+     Does the protocol for collecting telemetry use a single housekeeping request
      command for all apps or a unique housekeeping request command for each app?
   </B> <BR> <BR> <I>
-     It is unknown to the HK application because HK does not send the 
+     It is unknown to the HK application because HK does not send the
      housekeeping request command(s). These commands are usually sent by the
      scheduler. However, each CFS application is capable of receiving a unique
      housekeeping request command. The message ID of this command is specified in the
@@ -336,15 +336,15 @@
      housekeeping request commands for each app or using a single command for all
      apps. In the latter case, all the defines would be set to the same value.
   </I>
-            
+
   <B> (Q)
      What is the basic flow of the application?
   </B> <BR> <BR> <I>
-     The HK application uses a common application format. When the app starts, 
+     The HK application uses a common application format. When the app starts,
      initialization is performed, then the app enters an infinite loop waiting for
      commands from the software bus.
   </I>
-            
+
   <B> (Q)
      In general, what is done during initialization?
   </B> <BR> <BR> <I>
@@ -356,24 +356,24 @@
      variables. If any error is encountered during initialization, the application
      will send an event or syslog message, then terminate.
   </I>
-            
+
   <B> (Q)
-     How does the app react if the file to load the copy table (during 
+     How does the app react if the file to load the copy table (during
      initialization) is not found?
   </B> <BR> <BR> <I>
      HK will send an error event or a syslog message, then terminate.
   </I>
-     
+
   <B> (Q)
-     At what frequency is the housekeeping request command sent to the system 
+     At what frequency is the housekeeping request command sent to the system
      applications?
   </B> <BR> <BR> <I>
      The HK application does not send the housekeeping request command to the
-     system applications. The frequency of the housekeeping request commands is 
-     typically specified in the scheduler table and sent by the scheduler 
+     system applications. The frequency of the housekeeping request commands is
+     typically specified in the scheduler table and sent by the scheduler
      application.
   </I>
-            
+
   <B> (Q)
      What factor controls the input message timing?
   </B> <BR> <BR> <I>
@@ -382,7 +382,7 @@
      command(s). The housekeeping request command(s) are not sent by the HK
      application. Rather, it is typically sent by the scheduler application.
   </I>
-            
+
   <B> (Q)
      What determines the timing of the combined output messages?
   </B> <BR> <BR> <I>
@@ -391,12 +391,12 @@
      command periodically. Where 'x' is a parameter in the command that specifies the
      message ID of the output message to send.
   </I>
-            
+
   <B> (Q)
      How is the format of the combined output messages defined?
   </B> <BR> <BR> <I>
-     The output message format is defined by the entries in the copy table. If a 
-     format change to one or more output messages is needed, a new table must be 
+     The output message format is defined by the entries in the copy table. If a
+     format change to one or more output messages is needed, a new table must be
      loaded.
   </I>
 **/

--- a/fsw/inc/hk_msg.h
+++ b/fsw/inc/hk_msg.h
@@ -73,7 +73,7 @@ typedef struct
 /**
  *  \brief No-Operation command packet structure
  *
- *  For command details see #HK_RESET_CC
+ *  For command details see #HK_RESET_COUNTERS_CC
  */
 typedef struct
 {

--- a/fsw/inc/hk_msgdefs.h
+++ b/fsw/inc/hk_msgdefs.h
@@ -86,7 +86,7 @@
  *       to be designed such that they react to changes in the counter
  *       values that are reset by this command.
  */
-#define HK_RESET_CC 1
+#define HK_RESET_COUNTERS_CC 1
 
 /**\}*/
 

--- a/fsw/src/hk_app.h
+++ b/fsw/src/hk_app.h
@@ -136,21 +136,6 @@ int32 HK_AppInit(void);
 int32 HK_TableInit(void);
 
 /**
- * \brief Process a command pipe message
- *
- *  \par Description
- *       Processes a single software bus command pipe message. Checks
- *       the message and command IDs and calls the appropriate routine
- *       to handle the command.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param [in]  BufPtr Pointer to Software Bus buffer
- */
-void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr);
-
-/**
  * \brief Send Combined Housekeeping Message
  *
  *  \par Description
@@ -163,7 +148,7 @@ void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]  BufPtr Pointer to Software Bus buffer
  */
-void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr);
+void HK_SendCombinedPktCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Process housekeeping request
@@ -176,9 +161,9 @@ void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr);
  *       this command will increment the cmd error counter if an invalid cmd
  *       length is detected.
  *
- *  \param [in] Msg Pointer to command message header
+ *  \param [in] BufPtr Pointer to command message header
  */
-void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg);
+void HK_SendHkCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Process noop command
@@ -208,9 +193,9 @@ void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr);
  *
  *  \param [in]   BufPtr Pointer to Software Bus buffer
  *
- *  \sa #HK_RESET_CC
+ *  \sa #HK_RESET_COUNTERS_CC
  */
-void HK_ResetCtrsCmd(const CFE_SB_Buffer_t *BufPtr);
+void HK_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Reset housekeeping data
@@ -222,7 +207,7 @@ void HK_ResetCtrsCmd(const CFE_SB_Buffer_t *BufPtr);
  *  \par Assumptions, External Events, and Notes:
  *       None
  *
- *  \sa #HK_RESET_CC
+ *  \sa #HK_RESET_COUNTERS_CC
  */
 void HK_ResetHkData(void);
 

--- a/fsw/src/hk_dispatch.c
+++ b/fsw/src/hk_dispatch.c
@@ -1,0 +1,218 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,919-1, and identified as “Core Flight
+ * System (cFS) Housekeeping (HK) Application version 2.5.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  The CFS Housekeeping (HK) Application file containing the application
+ *  initialization routines, the main routine and the command interface.
+ */
+
+/************************************************************************
+** Includes
+*************************************************************************/
+#include "hk_app.h"
+#include "hk_events.h"
+#include "hk_msgids.h"
+#include "hk_dispatch.h"
+#include "hk_utils.h"
+
+#include <string.h>
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Verify Command Length                                           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
+{
+    int32             Status       = HK_SUCCESS;
+    CFE_SB_MsgId_t    MessageID    = CFE_SB_INVALID_MSG_ID; /* Init to invalid value */
+    CFE_MSG_FcnCode_t CommandCode  = 0;
+    size_t            ActualLength = 0;
+
+    CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
+
+    if (ExpectedLength != ActualLength)
+    {
+        CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+        CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
+
+        CFE_EVS_SendEvent(HK_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Cmd Msg with Bad length Rcvd: ID = 0x%08lX, CC = %d, Exp Len = %d, Len = %d",
+                          (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ExpectedLength,
+                          (int)ActualLength);
+
+        Status = HK_BAD_MSG_LENGTH_RC;
+    }
+
+    return Status;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Verify Non-Command Msg Length (Event is differnt)               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 HK_VerifyMsgLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
+{
+    int32          Status       = HK_SUCCESS;
+    CFE_SB_MsgId_t MessageID    = CFE_SB_INVALID_MSG_ID; /* Init to invalid value */
+    size_t         ActualLength = 0;
+
+    CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
+
+    if (ExpectedLength != ActualLength)
+    {
+        CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+
+        CFE_EVS_SendEvent(HK_MSG_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Msg with Bad length Rcvd: ID = 0x%08lX, Exp Len = %u, Len = %u",
+                          (unsigned long)CFE_SB_MsgIdToValue(MessageID), (unsigned int)ExpectedLength,
+                          (unsigned int)ActualLength);
+
+        Status = HK_BAD_MSG_LENGTH_RC;
+    }
+
+    return Status;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Send Combined Housekeeping Packet                               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HK_SendCombinedPktVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    if (HK_VerifyMsgLength(BufPtr, sizeof(HK_SendCombinedPktCmd_t)) == HK_SUCCESS)
+    {
+        HK_SendCombinedPktCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Housekeeping request                                            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HK_SendHkVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    if (HK_VerifyMsgLength(BufPtr, sizeof(HK_SendHkCmd_t)) == HK_SUCCESS)
+    {
+        HK_SendHkCmd(BufPtr);
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Noop command                                                    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HK_NoopVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HK_NoopCmd_t);
+
+    if (HK_VerifyCmdLength(BufPtr, ExpectedLength) == HK_SUCCESS)
+    {
+        HK_NoopCmd(BufPtr);
+    }
+    else
+    {
+        HK_AppData.ErrCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Reset counters command                                          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HK_ResetCountersVerifyDispatch(const CFE_SB_Buffer_t *BufPtr)
+{
+    size_t ExpectedLength = sizeof(HK_ResetCountersCmd_t);
+
+    if (HK_VerifyCmdLength(BufPtr, ExpectedLength) == HK_SUCCESS)
+    {
+        HK_ResetCountersCmd(BufPtr);
+    }
+    else
+    {
+        HK_AppData.ErrCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Process a command pipe message                                  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+{
+    CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID; /* Init to invalid value */
+    CFE_MSG_FcnCode_t CommandCode = 0;
+
+    CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+
+    switch (CFE_SB_MsgIdToValue(MessageID))
+    {
+        case HK_SEND_COMBINED_PKT_MID:
+            HK_SendCombinedPktVerifyDispatch(BufPtr);
+            break;
+
+        /* Request for HK's Housekeeping data...      */
+        case HK_SEND_HK_MID:
+            /* Send out HK's housekeeping data */
+            HK_SendHkVerifyDispatch(BufPtr);
+
+            /* Check for copy table load and runtime dump request */
+            if (HK_CheckStatusOfTables() != HK_SUCCESS)
+            {
+                HK_AppData.RunStatus = CFE_ES_RunStatus_APP_ERROR;
+            }
+            break;
+
+        /* HK ground commands   */
+        case HK_CMD_MID:
+
+            CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
+
+            switch (CommandCode)
+            {
+                case HK_NOOP_CC:
+                    HK_NoopVerifyDispatch(BufPtr);
+                    break;
+
+                case HK_RESET_COUNTERS_CC:
+                    HK_ResetCountersVerifyDispatch(BufPtr);
+                    break;
+
+                default:
+                    CFE_EVS_SendEvent(HK_CC_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "Cmd Msg with Invalid command code Rcvd -- ID = 0x%08lX, CC = %d",
+                                      (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
+                    HK_AppData.ErrCounter++;
+                    break;
+            }
+            break;
+
+        /* Incoming housekeeping data from other Subsystems...       */
+        default:
+            HK_ProcessIncomingHkData(BufPtr);
+            break;
+    }
+}

--- a/fsw/src/hk_dispatch.h
+++ b/fsw/src/hk_dispatch.h
@@ -1,0 +1,71 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,919-1, and identified as “Core Flight
+ * System (cFS) Housekeeping (HK) Application version 2.5.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *  The CFS Housekeeping (HK) Dispatch header file
+ */
+
+#ifndef HK_DISPATCH_H
+#define HK_DISPATCH_H
+
+/************************************************************************
+ * Includes
+ ************************************************************************/
+
+#include "cfe.h"
+
+/************************************************************************
+ * Exported Functions
+ ************************************************************************/
+
+/**
+ * \brief  Verify length of HK commands
+ *
+ *  \par Description
+ *       Function called when an HK command is received.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ *  \param[in] BufPtr         Pointer to the Software Buss Buffer
+ *  \param[in] ExpectedLength The expected lenght of the command
+ *
+ *  \return Command Length Status
+ *  \retval #HK_SUCCESS           Length Valid
+ *  \retval #HK_BAD_MSG_LENGTH_RC \copydoc HK_BAD_MSG_LENGTH_RC
+ */
+int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength);
+
+/**
+ * \brief Process a command pipe message
+ *
+ *  \par Description
+ *       Processes a single software bus command pipe message. Checks
+ *       the message and command IDs and calls the appropriate routine
+ *       to handle the command.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ *  \param [in]  BufPtr Pointer to Software Bus buffer
+ */
+void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr);
+
+#endif

--- a/fsw/src/hk_utils.c
+++ b/fsw/src/hk_utils.c
@@ -639,36 +639,6 @@ void HK_SetFlagsToNotPresent(CFE_SB_MsgId_t OutPkt)
     }
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* Verify Command Length                                           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
-{
-    int32             Status       = HK_SUCCESS;
-    CFE_SB_MsgId_t    MessageID    = CFE_SB_INVALID_MSG_ID; /* Init to invalid value */
-    CFE_MSG_FcnCode_t CommandCode  = 0;
-    size_t            ActualLength = 0;
-
-    CFE_MSG_GetSize(&BufPtr->Msg, &ActualLength);
-
-    if (ExpectedLength != ActualLength)
-    {
-        CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
-        CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
-
-        CFE_EVS_SendEvent(HK_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Cmd Msg with Bad length Rcvd: ID = 0x%08lX, CC = %d, Exp Len = %d, Len = %d",
-                          (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (int)ExpectedLength,
-                          (int)ActualLength);
-
-        Status = HK_BAD_MSG_LENGTH_RC;
-    }
-
-    return Status;
-}
-
 /************************/
 /*  End of File Comment */
 /************************/

--- a/fsw/src/hk_utils.h
+++ b/fsw/src/hk_utils.h
@@ -223,22 +223,4 @@ int32 HK_CheckForMissingData(CFE_SB_MsgId_t OutPktToCheck, CFE_SB_MsgId_t *Missi
  */
 void HK_SetFlagsToNotPresent(CFE_SB_MsgId_t OutPkt);
 
-/**
- * \brief  Verify length of HK commands
- *
- *  \par Description
- *       Function called when an HK command is received.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param[in] BufPtr         Pointer to the Software Buss Buffer
- *  \param[in] ExpectedLength The expected lenght of the command
- *
- *  \return Command Length Status
- *  \retval #HK_SUCCESS           Length Valid
- *  \retval #HK_BAD_MSG_LENGTH_RC \copydoc HK_BAD_MSG_LENGTH_RC
- */
-int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength);
-
 #endif

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -12,6 +12,7 @@ add_cfe_coverage_stubs("hk_internal"
   stubs/hk_global_stubs.c
   stubs/hk_utils_stubs.c
   stubs/hk_app_stubs.c
+  stubs/hk_dispatch_stubs.c
 )
 
 # Link with the cfe core stubs and unit test assert libs

--- a/unit-test/hk_dispatch_tests.c
+++ b/unit-test/hk_dispatch_tests.c
@@ -1,0 +1,253 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,919-1, and identified as “Core Flight
+ * System (cFS) Housekeeping (HK) Application version 2.5.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+ * App Includes
+ */
+
+#include "hk_dispatch.h"
+#include "hk_msg.h"
+#include "hk_events.h"
+#include "hk_msgids.h"
+#include "hk_test_utils.h"
+
+/* UT includes */
+#include "uttest.h"
+#include "utassert.h"
+#include "utstubs.h"
+
+#include <unistd.h>
+#include <stdlib.h>
+#include "cfe.h"
+
+/*
+ * Helper functions
+ */
+static void HK_Dispatch_Test_SetupMsg(CFE_SB_MsgId_t MsgId, CFE_MSG_FcnCode_t FcnCode, size_t MsgSize)
+{
+    /* Note some paths get the MsgId/FcnCode multiple times, so register accordingly, just in case */
+    CFE_SB_MsgId_t    RegMsgId[2]   = {MsgId, MsgId};
+    CFE_MSG_FcnCode_t RegFcnCode[2] = {FcnCode, FcnCode};
+    size_t            RegMsgSize[2] = {MsgSize, MsgSize};
+
+    UT_ResetState(UT_KEY(CFE_MSG_GetMsgId));
+    UT_ResetState(UT_KEY(CFE_MSG_GetFcnCode));
+    UT_ResetState(UT_KEY(CFE_MSG_GetSize));
+
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), RegMsgId, sizeof(RegMsgId), true);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), RegFcnCode, sizeof(RegFcnCode), true);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), RegMsgSize, sizeof(RegMsgSize), true);
+}
+
+/**********************************************************************/
+/*                                                                    */
+/* Test functions for HK_AppPipe                                      */
+/*                                                                    */
+/**********************************************************************/
+
+/*
+ * Function under test: HK_AppPipe
+ *
+ * Case: Tests the case in which a "Send Combined Packet" message
+ *       received with the expected length.
+ */
+void Test_HK_AppPipe_SendCombinedPktCmd(void)
+{
+    CFE_SB_Buffer_t Buf;
+
+    memset(&Buf, 0, sizeof(Buf));
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_SEND_COMBINED_PKT_MID), 0, sizeof(HK_SendCombinedPktCmd_t));
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_SendCombinedPktCmd, 1);
+
+    /* Bad Length */
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_SEND_COMBINED_PKT_MID), 0, 1);
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_SendCombinedPktCmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_MSG_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+}
+
+/*
+ * Function under test: HK_AppPipe
+ *
+ * Case: Tests the case in which a "Housekeeping Request" message
+ *       received with the expected length.
+ */
+void Test_HK_AppPipe_SendHkCmd(void)
+{
+    CFE_SB_Buffer_t Buf;
+
+    memset(&Buf, 0, sizeof(Buf));
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_SEND_HK_MID), 0, sizeof(HK_SendHkCmd_t));
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_SendHkCmd, 1);
+
+    /* Bad Length */
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_SEND_HK_MID), 0, 1);
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_SendHkCmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_MSG_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+
+    /* Bad Table Status */
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_SEND_HK_MID), 0, sizeof(HK_SendHkCmd_t));
+    UT_SetDefaultReturnValue(UT_KEY(HK_CheckStatusOfTables), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_SendHkCmd, 2);
+    UtAssert_UINT32_EQ(HK_AppData.RunStatus, CFE_ES_RunStatus_APP_ERROR);
+}
+
+/*
+ * Function under test: HK_AppPipe
+ *
+ * Case: Tests the case in which a Command message is received with a
+ *       "No Operation" command code.
+ */
+void Test_HK_AppPipe_NoopCmd(void)
+{
+    CFE_SB_Buffer_t Buf;
+
+    memset(&Buf, 0, sizeof(Buf));
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_CMD_MID), HK_NOOP_CC, sizeof(HK_NoopCmd_t));
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_NoopCmd, 1);
+    UtAssert_ZERO(HK_AppData.ErrCounter);
+
+    /* Bad Length */
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_CMD_MID), HK_NOOP_CC, 1);
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_NoopCmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_CMD_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_UINT8_EQ(HK_AppData.ErrCounter, 1);
+}
+
+/*
+ * Function under test: HK_AppPipe
+ *
+ * Case: Tests the case in which a Command message is received with a
+ *       "Reset" command code.
+ */
+void Test_HK_AppPipe_ResetCountersCmd(void)
+{
+    CFE_SB_Buffer_t Buf;
+
+    memset(&Buf, 0, sizeof(Buf));
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_CMD_MID), HK_RESET_COUNTERS_CC, sizeof(HK_ResetCountersCmd_t));
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_ResetCountersCmd, 1);
+    UtAssert_ZERO(HK_AppData.ErrCounter);
+
+    /* Bad Length */
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_CMD_MID), HK_RESET_COUNTERS_CC, 1);
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_ResetCountersCmd, 1);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_CMD_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_UINT8_EQ(HK_AppData.ErrCounter, 1);
+}
+
+/*
+ * Function under test: HK_AppPipe
+ *
+ * Case: Tests the case in which a Command message is received with an
+ *       unknown command code.
+ */
+void Test_HK_AppPipe_UnknownCmd(void)
+{
+    CFE_SB_Buffer_t Buf;
+
+    memset(&Buf, 0, sizeof(Buf));
+    HK_Dispatch_Test_SetupMsg(CFE_SB_ValueToMsgId(HK_CMD_MID), 47, sizeof(HK_NoopCmd_t));
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_CC_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_UINT8_EQ(HK_AppData.ErrCounter, 1);
+}
+
+/*
+ * Function under test: HK_AppPipe
+ *
+ * Case: Tests the case in which a message is received with an unknown
+ *       message ID, triggering a call to HK_ProcessIncomingHkData.
+ */
+void Test_HK_AppPipe_ProcessIncoming(void)
+{
+    CFE_SB_Buffer_t Buf;
+
+    memset(&Buf, 0, sizeof(Buf));
+    HK_Dispatch_Test_SetupMsg(HK_UT_MID_100, 0, sizeof(HK_NoopCmd_t));
+
+    /* Act */
+    HK_AppPipe(&Buf);
+
+    UtAssert_STUB_COUNT(HK_ProcessIncomingHkData, 1);
+}
+
+/****************************************************************************/
+
+/*
+ * Register the test cases to execute with the unit test tool
+ */
+void UtTest_Setup(void)
+{
+    UtTest_Add(Test_HK_AppPipe_SendCombinedPktCmd, HK_Test_Setup, HK_Test_TearDown,
+               "Test_HK_AppPipe_SendCombinedPktCmd");
+    UtTest_Add(Test_HK_AppPipe_SendHkCmd, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppPipe_SendHkCmd");
+    UtTest_Add(Test_HK_AppPipe_NoopCmd, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppPipe_NoopCmd");
+    UtTest_Add(Test_HK_AppPipe_ResetCountersCmd, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppPipe_ResetCountersCmd");
+    UtTest_Add(Test_HK_AppPipe_UnknownCmd, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppPipe_UnknownCmd");
+    UtTest_Add(Test_HK_AppPipe_ProcessIncoming, HK_Test_Setup, HK_Test_TearDown, "Test_HK_AppPipe_ProcessIncoming");
+}

--- a/unit-test/stubs/hk_app_stubs.c
+++ b/unit-test/stubs/hk_app_stubs.c
@@ -53,30 +53,6 @@ void HK_AppMain(void)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HK_AppPipe()
- * ----------------------------------------------------
- */
-void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
-{
-    UT_GenStub_AddParam(HK_AppPipe, const CFE_SB_Buffer_t *, BufPtr);
-
-    UT_GenStub_Execute(HK_AppPipe, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for HK_HousekeepingCmd()
- * ----------------------------------------------------
- */
-void HK_HousekeepingCmd(const CFE_MSG_CommandHeader_t *Msg)
-{
-    UT_GenStub_AddParam(HK_HousekeepingCmd, const CFE_MSG_CommandHeader_t *, Msg);
-
-    UT_GenStub_Execute(HK_HousekeepingCmd, Basic, NULL);
-}
-
-/*
- * ----------------------------------------------------
  * Generated stub function for HK_NoopCmd()
  * ----------------------------------------------------
  */
@@ -89,14 +65,14 @@ void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HK_ResetCtrsCmd()
+ * Generated stub function for HK_ResetCountersCmd()
  * ----------------------------------------------------
  */
-void HK_ResetCtrsCmd(const CFE_SB_Buffer_t *BufPtr)
+void HK_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_GenStub_AddParam(HK_ResetCtrsCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(HK_ResetCountersCmd, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(HK_ResetCtrsCmd, Basic, NULL);
+    UT_GenStub_Execute(HK_ResetCountersCmd, Basic, NULL);
 }
 
 /*
@@ -112,14 +88,26 @@ void HK_ResetHkData(void)
 
 /*
  * ----------------------------------------------------
- * Generated stub function for HK_SendCombinedHKCmd()
+ * Generated stub function for HK_SendCombinedPktCmd()
  * ----------------------------------------------------
  */
-void HK_SendCombinedHKCmd(const CFE_SB_Buffer_t *BufPtr)
+void HK_SendCombinedPktCmd(const CFE_SB_Buffer_t *BufPtr)
 {
-    UT_GenStub_AddParam(HK_SendCombinedHKCmd, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(HK_SendCombinedPktCmd, const CFE_SB_Buffer_t *, BufPtr);
 
-    UT_GenStub_Execute(HK_SendCombinedHKCmd, Basic, NULL);
+    UT_GenStub_Execute(HK_SendCombinedPktCmd, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_SendHkCmd()
+ * ----------------------------------------------------
+ */
+void HK_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HK_SendHkCmd, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_SendHkCmd, Basic, NULL);
 }
 
 /*

--- a/unit-test/stubs/hk_dispatch_stubs.c
+++ b/unit-test/stubs/hk_dispatch_stubs.c
@@ -1,0 +1,56 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,919-1, and identified as “Core Flight
+ * System (cFS) Housekeeping (HK) Application version 2.5.1”
+ *
+ * Copyright (c) 2021 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ * Auto-Generated stub implementations for functions defined in hk_dispatch header
+ */
+
+#include "hk_dispatch.h"
+#include "utgenstub.h"
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_AppPipe()
+ * ----------------------------------------------------
+ */
+void HK_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+{
+    UT_GenStub_AddParam(HK_AppPipe, const CFE_SB_Buffer_t *, BufPtr);
+
+    UT_GenStub_Execute(HK_AppPipe, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for HK_VerifyCmdLength()
+ * ----------------------------------------------------
+ */
+int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
+{
+    UT_GenStub_SetupReturnBuffer(HK_VerifyCmdLength, int32);
+
+    UT_GenStub_AddParam(HK_VerifyCmdLength, const CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(HK_VerifyCmdLength, size_t, ExpectedLength);
+
+    UT_GenStub_Execute(HK_VerifyCmdLength, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(HK_VerifyCmdLength, int32);
+}

--- a/unit-test/stubs/hk_utils_stubs.c
+++ b/unit-test/stubs/hk_utils_stubs.c
@@ -170,20 +170,3 @@ int32 HK_ValidateHkCopyTable(void *TblPtr)
 
     return UT_GenStub_GetReturnValue(HK_ValidateHkCopyTable, int32);
 }
-
-/*
- * ----------------------------------------------------
- * Generated stub function for HK_VerifyCmdLength()
- * ----------------------------------------------------
- */
-int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
-{
-    UT_GenStub_SetupReturnBuffer(HK_VerifyCmdLength, int32);
-
-    UT_GenStub_AddParam(HK_VerifyCmdLength, const CFE_SB_Buffer_t *, BufPtr);
-    UT_GenStub_AddParam(HK_VerifyCmdLength, size_t, ExpectedLength);
-
-    UT_GenStub_Execute(HK_VerifyCmdLength, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(HK_VerifyCmdLength, int32);
-}


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HK/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Isolate the message verification and dispatch from the general message processing.  Functions in the "cmds" file now strictly handle the command content, and do not get involved in general validation.

The "Custom" code isolation is also in a separate dispatcher.  There is a separate issue to address this.

Fixes #45

**Testing performed**
Build and run HK in CFE and run all tests

**Expected behavior changes**
No change in actual implementation, splits up source files into smaller units only

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
