### PR TITLE
Fix #51, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -49,7 +49,7 @@ HK_AppData_t HK_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void HK_AppMain(void)
 {
-    int32            Status = CFE_SUCCESS;
+    CFE_Status_t     Status = CFE_SUCCESS;
     CFE_SB_Buffer_t *BufPtr = NULL;
 
     /*
@@ -128,9 +128,9 @@ void HK_AppMain(void)
 /* HK application initialization routine                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HK_AppInit(void)
+CFE_Status_t HK_AppInit(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     HK_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
 
@@ -220,9 +220,9 @@ int32 HK_AppInit(void)
 /* HK application table initialization routine                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HK_TableInit(void)
+CFE_Status_t HK_TableInit(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /* Register The HK Copy Table */
     Status = CFE_TBL_Register(&HK_AppData.CopyTableHandle, HK_COPY_TABLE_NAME,

--- a/fsw/src/hk_app.h
+++ b/fsw/src/hk_app.h
@@ -119,7 +119,7 @@ void HK_AppMain(void);
  *  \return Execution status, see \ref CFEReturnCodes
  *  \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 HK_AppInit(void);
+CFE_Status_t HK_AppInit(void);
 
 /**
  * \brief Initialize the Copy Table and the Runtime Table
@@ -133,7 +133,7 @@ int32 HK_AppInit(void);
  *
  *  \sa #HK_AppInit
  */
-int32 HK_TableInit(void);
+CFE_Status_t HK_TableInit(void);
 
 /**
  * \brief Send Combined Housekeeping Message

--- a/fsw/src/hk_utils.c
+++ b/fsw/src/hk_utils.c
@@ -114,7 +114,7 @@ int32 HK_ValidateHkCopyTable(void *TblPtr)
 /* HK process new copy table                                       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
+CFE_Status_t HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
 {
     hk_copy_table_entry_t * StartOfCopyTable = NULL;
     hk_copy_table_entry_t * OuterCpyEntry    = NULL;
@@ -128,7 +128,7 @@ int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_en
     int32                   SizeOfThisPacket;
     int32                   FurthestByteFromThisEntry;
     CFE_SB_Buffer_t *       NewPacketAddr;
-    int32                   Result;
+    CFE_Status_t            Result;
 
     /* Ensure that the input arguments are valid */
     if (((void *)CpyTblPtr == NULL) || ((void *)RtTblPtr == NULL))
@@ -261,7 +261,7 @@ int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_en
 /* HK Tear down old copy table                                     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
+CFE_Status_t HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
 {
     hk_copy_table_entry_t * StartOfCopyTable = NULL;
     hk_copy_table_entry_t * OuterCpyEntry    = NULL;
@@ -274,7 +274,7 @@ int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_e
     CFE_SB_MsgId_t          MidOfThisPacket;
     void *                  OutputPktAddr = NULL;
     void *                  SavedPktAddr  = NULL;
-    int32                   Result;
+    CFE_Status_t            Result;
 
     /* Ensure that the input arguments are valid */
     if (((void *)CpyTblPtr == NULL) || ((void *)RtTblPtr == NULL))

--- a/fsw/src/hk_utils.h
+++ b/fsw/src/hk_utils.h
@@ -103,7 +103,7 @@ int32 HK_ValidateHkCopyTable(void *TblPtr);
  * \retval #CFE_SUCCESS              \copydoc CFE_SUCCESS
  * \retval #HK_NULL_POINTER_DETECTED \copydoc HK_NULL_POINTER_DETECTED
  */
-int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr);
+CFE_Status_t HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr);
 
 /**
  * \brief Tear Down Old Copy Table
@@ -122,7 +122,7 @@ int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_en
  * \retval #CFE_SUCCESS              \copydoc CFE_SUCCESS
  * \retval #HK_NULL_POINTER_DETECTED \copydoc HK_NULL_POINTER_DETECTED
  */
-int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr);
+CFE_Status_t HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr);
 
 /**
  * \brief Send combined output message

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -266,9 +266,9 @@ void Test_HK_AppMain_RcvBufTimeoutCheckFail(void)
 void Test_HK_AppInit_Success(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "HK Initialized.  Version %%d.%%d.%%d.%%d");
 
     /* Set return codes for table functions so that HK_TableInit succeeds. */
@@ -305,9 +305,9 @@ void Test_HK_AppInit_Success(void)
 void Test_HK_AppInit_EVSRegFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedSysLogString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "HK: error registering for event services: 0x%%08X\n");
 
@@ -332,10 +332,10 @@ void Test_HK_AppInit_EVSRegFail(void)
 void Test_HK_AppInit_SBCreatePipeFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32 ForcedReturnVal = -1;
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    int32        ForcedReturnVal = -1;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Creating SB Pipe,RC=0x%%08X");
 
@@ -368,10 +368,10 @@ void Test_HK_AppInit_SBCreatePipeFail(void)
 void Test_HK_AppInit_SBSubscribe1Fail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32 ForcedReturnVal = -1;
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    int32        ForcedReturnVal = -1;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error Subscribing to HK Snd Cmb Pkt, MID=0x%%08X, RC=0x%%08X");
@@ -405,10 +405,10 @@ void Test_HK_AppInit_SBSubscribe1Fail(void)
 void Test_HK_AppInit_SBSubscribe2Fail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32 ForcedReturnVal = -1;
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    int32        ForcedReturnVal = -1;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error Subscribing to HK Request, MID=0x%%08X, RC=0x%%08X");
@@ -442,10 +442,10 @@ void Test_HK_AppInit_SBSubscribe2Fail(void)
 void Test_HK_AppInit_SBSubscribe3Fail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32 ForcedReturnVal = -1;
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    int32        ForcedReturnVal = -1;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error Subscribing to HK Gnd Cmds, MID=0x%%08X, RC=0x%%08X");
@@ -479,10 +479,10 @@ void Test_HK_AppInit_SBSubscribe3Fail(void)
 void Test_HK_AppInit_PoolCreateFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32 ForcedReturnVal = -1;
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    int32        ForcedReturnVal = -1;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Creating Memory Pool,RC=0x%%08X");
 
@@ -515,7 +515,7 @@ void Test_HK_AppInit_PoolCreateFail(void)
 void Test_HK_AppInit_TblInitFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
+    CFE_Status_t ReturnValue;
 
     /* forcing CFE_TBL_Register to fail indirectly causes HK_TableInit to fail */
     int32 ForcedReturnVal = -1;
@@ -540,10 +540,10 @@ void Test_HK_AppInit_TblInitFail(void)
 void Test_HK_AppInit_SendEventFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    uint8 call_count_CFE_ES_WriteToSysLog;
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    uint8        call_count_CFE_ES_WriteToSysLog;
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedSysLogString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "HK App:Error Sending Initialization Event,RC=0x%%08X\n");
 
@@ -578,7 +578,7 @@ void Test_HK_AppInit_SendEventFail(void)
 void Test_HK_TableInit_Success(void)
 {
     /* Arrange */
-    int32 ReturnValue;
+    CFE_Status_t ReturnValue;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
     UT_SetDefaultReturnValue(UT_KEY(HK_ProcessNewCopyTable), CFE_SUCCESS);
@@ -602,7 +602,7 @@ void Test_HK_TableInit_Success(void)
 void Test_HK_TableInit_RegisterCpyTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
+    CFE_Status_t ReturnValue;
 
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
@@ -637,9 +637,9 @@ void Test_HK_TableInit_RegisterCpyTblFail(void)
 void Test_HK_TableInit_RegisterRtTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Registering Runtime Table,RC=0x%%08X");
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_Register), 2, -1);
@@ -671,9 +671,9 @@ void Test_HK_TableInit_RegisterRtTblFail(void)
 void Test_HK_TableInit_LoadCpyTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Loading Copy Table,RC=0x%%08X");
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_Load), -1);
@@ -705,9 +705,9 @@ void Test_HK_TableInit_LoadCpyTblFail(void)
 void Test_HK_TableInit_ManageCpyTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error from TBL Manage call for Copy Table,RC=0x%%08X");
 
@@ -740,9 +740,9 @@ void Test_HK_TableInit_ManageCpyTblFail(void)
 void Test_HK_TableInit_ManageRtTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Error from TBL Manage call for Runtime Table,RC=0x%%08X");
 
@@ -775,9 +775,9 @@ void Test_HK_TableInit_ManageRtTblFail(void)
 void Test_HK_TableInit_GetAddrCpyTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Getting Adr for Cpy Tbl,RC=0x%%08X");
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);
@@ -809,9 +809,9 @@ void Test_HK_TableInit_GetAddrCpyTblFail(void)
 void Test_HK_TableInit_GetAddrRtTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Error Getting Adr for Runtime Table,RC=0x%%08X");
 
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_INFO_UPDATED);
@@ -844,9 +844,9 @@ void Test_HK_TableInit_GetAddrRtTblFail(void)
 void Test_HK_TableInit_ProcessNewCpyTblFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Process New Copy Table Failed, status = 0x%%08X");
 

--- a/unit-test/hk_utils_tests.c
+++ b/unit-test/hk_utils_tests.c
@@ -328,7 +328,7 @@ void Test_HK_ProcessNewCopyTable_NullCpyTbl(void)
     /* Arrange */
     hk_runtime_tbl_entry_t RtTblPtr;
     int32                  strCmpResult;
-    int32                  ReturnValue;
+    CFE_Status_t           ReturnValue;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -365,7 +365,7 @@ void Test_HK_ProcessNewCopyTable_NullRtTbl(void)
     hk_copy_table_entry_t CpyTblPtr;
     int32                 strCmpResult;
     char                  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
-    int32                 ReturnValue;
+    CFE_Status_t          ReturnValue;
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Null pointer detected in new copy tbl processing: CpyTbl = %%p, RtTbl = %%p");
@@ -397,10 +397,10 @@ void Test_HK_ProcessNewCopyTable_NullRtTbl(void)
 void Test_HK_ProcessNewCopyTable_PoolBufFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 ExtraSubscribes = 0;
-    int32 strCmpResult;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        ExtraSubscribes = 0;
+    int32        strCmpResult;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -463,10 +463,10 @@ void Test_HK_ProcessNewCopyTable_PoolBufFail(void)
 void Test_HK_ProcessNewCopyTable_SubscribeFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 strCmpResult;
-    int32 i;
-    int32 SubscriptionCount = 0;
+    CFE_Status_t ReturnValue;
+    int32        strCmpResult;
+    int32        i;
+    int32        SubscriptionCount = 0;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -525,9 +525,9 @@ void Test_HK_ProcessNewCopyTable_SubscribeFail(void)
 void Test_HK_ProcessNewCopyTable_Success(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 ExtraSubscribes = 0;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        ExtraSubscribes = 0;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -574,9 +574,9 @@ void Test_HK_ProcessNewCopyTable_Success(void)
 void Test_HK_ProcessNewCopyTable_Success2(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 ExtraSubscribes = 0;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        ExtraSubscribes = 0;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -623,9 +623,9 @@ void Test_HK_ProcessNewCopyTable_Success2(void)
 void Test_HK_ProcessNewCopyTable_PacketSizeZero(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 ExtraSubscribes = 0;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        ExtraSubscribes = 0;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -672,9 +672,9 @@ void Test_HK_ProcessNewCopyTable_PacketSizeZero(void)
 void Test_HK_ProcessNewCopyTable_AllPacketsSizeZero(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 ExtraSubscribes = 0;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        ExtraSubscribes = 0;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -725,9 +725,9 @@ void Test_HK_ProcessNewCopyTable_AllPacketsSizeZero(void)
 void Test_HK_ProcessNewCopyTable_EmptyTable(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 SubscriptionCount = 0;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        SubscriptionCount = 0;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -773,7 +773,7 @@ void Test_HK_TearDownOldCopyTable_NullCpyTbl(void)
     /* Arrange */
     hk_runtime_tbl_entry_t RtTblPtr;
     int32                  strCmpResult;
-    int32                  ReturnValue;
+    CFE_Status_t           ReturnValue;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -809,7 +809,7 @@ void Test_HK_TearDownOldCopyTable_NullRtTbl(void)
     /* Arrange */
     hk_copy_table_entry_t CpyTblPtr;
     int32                 strCmpResult;
-    int32                 ReturnValue;
+    CFE_Status_t          ReturnValue;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -843,9 +843,9 @@ void Test_HK_TearDownOldCopyTable_NullRtTbl(void)
 void Test_HK_TearDownOldCopyTable_PoolFreeFail(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 strCmpResult;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        strCmpResult;
 
     char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
@@ -895,8 +895,8 @@ void Test_HK_TearDownOldCopyTable_PoolFreeFail(void)
 void Test_HK_TearDownOldCopyTable_Success(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
+    CFE_Status_t ReturnValue;
+    int32        i;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -930,9 +930,9 @@ void Test_HK_TearDownOldCopyTable_Success(void)
 void Test_HK_TearDownOldCopyTable_EmptyTable(void)
 {
     /* Arrange */
-    int32 ReturnValue;
-    int32 i;
-    int32 SubscriptionCount = 0;
+    CFE_Status_t ReturnValue;
+    int32        i;
+    int32        SubscriptionCount = 0;
 
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];
     hk_copy_table_entry_t  CopyTblPtr[HK_COPY_TABLE_ENTRIES];
@@ -973,7 +973,7 @@ void Test_HK_TearDownOldCopyTable_EmptyTable(void)
 void Test_HK_TearDownOldCopyTable_Success2(void)
 {
     /* Arrange */
-    int32                  ReturnValue;
+    CFE_Status_t           ReturnValue;
     int32                  i;
     CFE_SB_Buffer_t        Buffer;
     hk_runtime_tbl_entry_t RtTblPtr[HK_COPY_TABLE_ENTRIES];

--- a/unit-test/stubs/hk_app_stubs.c
+++ b/unit-test/stubs/hk_app_stubs.c
@@ -31,13 +31,13 @@
  * Generated stub function for HK_AppInit()
  * ----------------------------------------------------
  */
-int32 HK_AppInit(void)
+CFE_Status_t HK_AppInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(HK_AppInit, int32);
+    UT_GenStub_SetupReturnBuffer(HK_AppInit, CFE_Status_t);
 
     UT_GenStub_Execute(HK_AppInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HK_AppInit, int32);
+    return UT_GenStub_GetReturnValue(HK_AppInit, CFE_Status_t);
 }
 
 /*
@@ -115,11 +115,11 @@ void HK_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HK_TableInit()
  * ----------------------------------------------------
  */
-int32 HK_TableInit(void)
+CFE_Status_t HK_TableInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(HK_TableInit, int32);
+    UT_GenStub_SetupReturnBuffer(HK_TableInit, CFE_Status_t);
 
     UT_GenStub_Execute(HK_TableInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HK_TableInit, int32);
+    return UT_GenStub_GetReturnValue(HK_TableInit, CFE_Status_t);
 }

--- a/unit-test/stubs/hk_utils_stubs.c
+++ b/unit-test/stubs/hk_utils_stubs.c
@@ -102,16 +102,16 @@ void HK_ProcessIncomingHkData(const CFE_SB_Buffer_t *BufPtr)
  * Generated stub function for HK_ProcessNewCopyTable()
  * ----------------------------------------------------
  */
-int32 HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
+CFE_Status_t HK_ProcessNewCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
 {
-    UT_GenStub_SetupReturnBuffer(HK_ProcessNewCopyTable, int32);
+    UT_GenStub_SetupReturnBuffer(HK_ProcessNewCopyTable, CFE_Status_t);
 
     UT_GenStub_AddParam(HK_ProcessNewCopyTable, hk_copy_table_entry_t *, CpyTblPtr);
     UT_GenStub_AddParam(HK_ProcessNewCopyTable, hk_runtime_tbl_entry_t *, RtTblPtr);
 
     UT_GenStub_Execute(HK_ProcessNewCopyTable, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HK_ProcessNewCopyTable, int32);
+    return UT_GenStub_GetReturnValue(HK_ProcessNewCopyTable, CFE_Status_t);
 }
 
 /*
@@ -143,16 +143,16 @@ void HK_SetFlagsToNotPresent(CFE_SB_MsgId_t OutPkt)
  * Generated stub function for HK_TearDownOldCopyTable()
  * ----------------------------------------------------
  */
-int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
+CFE_Status_t HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_entry_t *RtTblPtr)
 {
-    UT_GenStub_SetupReturnBuffer(HK_TearDownOldCopyTable, int32);
+    UT_GenStub_SetupReturnBuffer(HK_TearDownOldCopyTable, CFE_Status_t);
 
     UT_GenStub_AddParam(HK_TearDownOldCopyTable, hk_copy_table_entry_t *, CpyTblPtr);
     UT_GenStub_AddParam(HK_TearDownOldCopyTable, hk_runtime_tbl_entry_t *, RtTblPtr);
 
     UT_GenStub_Execute(HK_TearDownOldCopyTable, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(HK_TearDownOldCopyTable, int32);
+    return UT_GenStub_GetReturnValue(HK_TearDownOldCopyTable, CFE_Status_t);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #51
  - most `int32` return codes converted over to `CFE_Status_t`
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt