### PR TITLE
Fix #4, Add PacketNotFoundCtr to HK AppData/Tlm

### DIFF
--- a/docs/dox_src/cfs_hk.dox
+++ b/docs/dox_src/cfs_hk.dox
@@ -233,7 +233,13 @@
   The HK app will not zero-out or alter the missing data section(s) in any way.
   The missing data values will match the last 'good' section received.
 
-  <H2>9. Using the Memory Pool handle to get mempool stats</H2>
+  <H2>9. Monitoring the 'Packet Not Found" counter</H2>
+  
+  If the combined HK Packet cannot be found in the current HK Copy Table, an
+  informational event will be sent, and the #HK_HkTlm_Payload_t.PacketNotFoundCtr
+  will be incremented.
+
+  <H2>10. Using the Memory Pool handle to get mempool stats</H2>
 
   The HK memory pool is used to allocate the memory needed to store the output
   packets. Each time a new copy table is processed, the memory for the output

--- a/fsw/inc/hk_msg.h
+++ b/fsw/inc/hk_msg.h
@@ -96,7 +96,8 @@ typedef struct
     uint8              ErrCounter;          /**< \brief Count of invalid commands received */
     uint16             Padding;             /**< \brief Padding to force 32 bit alignment */
     uint16             CombinedPacketsSent; /**< \brief Count of combined tlm pkts sent */
-    uint16             MissingDataCtr;      /**< \brief Number of times missing data was detected */
+    uint8              PacketNotFoundCtr;   /**< \brief Number of times a requested packet was not found */
+    uint8              MissingDataCtr;      /**< \brief Number of times missing data was detected */
     CFE_ES_MemHandle_t MemPoolHandle;       /**< \brief Memory pool handle used to get mempool diags */
 } HK_HkTlm_Payload_t;
 

--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -330,6 +330,7 @@ void HK_SendHkCmd(const CFE_SB_Buffer_t *BufPtr)
     /* copy data into housekeeping packet */
     PayloadPtr->CmdCounter          = HK_AppData.CmdCounter;
     PayloadPtr->ErrCounter          = HK_AppData.ErrCounter;
+    PayloadPtr->PacketNotFoundCtr   = HK_AppData.PacketNotFoundCtr;
     PayloadPtr->MissingDataCtr      = HK_AppData.MissingDataCtr;
     PayloadPtr->CombinedPacketsSent = HK_AppData.CombinedPacketsSent;
     PayloadPtr->MemPoolHandle       = HK_AppData.MemPoolHandle;
@@ -373,6 +374,7 @@ void HK_ResetHkData(void)
     HK_AppData.CmdCounter          = 0;
     HK_AppData.ErrCounter          = 0;
     HK_AppData.CombinedPacketsSent = 0;
+    HK_AppData.PacketNotFoundCtr   = 0;
     HK_AppData.MissingDataCtr      = 0;
 }
 

--- a/fsw/src/hk_app.h
+++ b/fsw/src/hk_app.h
@@ -68,7 +68,8 @@ typedef struct
     uint8           CmdCounter; /**< \brief Number of valid commands received */
     uint8           ErrCounter; /**< \brief Number of invalid commands received */
 
-    uint16 MissingDataCtr;      /**< \brief Number of times missing data was detected */
+    uint8  PacketNotFoundCtr;   /**< \brief Number of times a requested packet was not found */
+    uint8  MissingDataCtr;      /**< \brief Number of times missing data was detected */
     uint16 CombinedPacketsSent; /**< \brief Count of combined output msgs sent */
 
     CFE_ES_MemHandle_t MemPoolHandle; /**< \brief HK mempool handle for output pkts */

--- a/fsw/src/hk_utils.c
+++ b/fsw/src/hk_utils.c
@@ -409,6 +409,8 @@ void HK_SendCombinedHkPacket(CFE_SB_MsgId_t WhichMidToSend)
 
     if (PacketFound == false)
     {
+        HK_AppData.PacketNotFoundCtr++;
+
         CFE_EVS_SendEvent(HK_UNKNOWN_COMBINED_PACKET_EID, CFE_EVS_EventType_INFORMATION,
                           "Combined HK Packet 0x%08lX is not found in current HK Copy Table",
                           (unsigned long)CFE_SB_MsgIdToValue(WhichMidToSend));

--- a/fsw/src/hk_utils.h
+++ b/fsw/src/hk_utils.h
@@ -129,8 +129,9 @@ int32 HK_TearDownOldCopyTable(hk_copy_table_entry_t *CpyTblPtr, hk_runtime_tbl_e
  *
  * \par Description
  *        This routine searches for the combined HK that contains the specified
- *        MID.  Once found, the packet is sent.  If not found, an event is
- *        generated. Also sets the data pieces for this output pkt
+ *        MID.  Once found, the packet is sent.  If not found, PacketNotFoundCtr
+ *        is incremented, and an event is generated. Also sets the data pieces
+ *        for this output pkt
  *
  * \par Assumptions, External Events, and Notes:
  *          None

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -930,8 +930,9 @@ void Test_HK_SendHkCmd(void)
     /* Setup app data values */
     HK_AppData.CmdCounter          = 1;
     HK_AppData.ErrCounter          = 2;
-    HK_AppData.MissingDataCtr      = 3;
-    HK_AppData.CombinedPacketsSent = 4;
+    HK_AppData.PacketNotFoundCtr   = 3;
+    HK_AppData.MissingDataCtr      = 4;
+    HK_AppData.CombinedPacketsSent = 5;
     HK_AppData.MemPoolHandle       = HK_UT_MEMPOOL_1;
 
     memset(&Msg, 0, sizeof(Msg));
@@ -946,6 +947,7 @@ void Test_HK_SendHkCmd(void)
     PayloadPtr = &HK_AppData.HkPacket.Payload;
     UtAssert_INT32_EQ(HK_AppData.CmdCounter, PayloadPtr->CmdCounter);
     UtAssert_INT32_EQ(HK_AppData.ErrCounter, PayloadPtr->ErrCounter);
+    UtAssert_INT32_EQ(HK_AppData.PacketNotFoundCtr, PayloadPtr->PacketNotFoundCtr);
     UtAssert_INT32_EQ(HK_AppData.MissingDataCtr, PayloadPtr->MissingDataCtr);
     UtAssert_INT32_EQ(HK_AppData.CombinedPacketsSent, PayloadPtr->CombinedPacketsSent);
     UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(HK_AppData.MemPoolHandle, PayloadPtr->MemPoolHandle),
@@ -1055,6 +1057,7 @@ void Test_HK_ResetHkData(void)
     HK_AppData.CmdCounter          = 1;
     HK_AppData.ErrCounter          = 1;
     HK_AppData.CombinedPacketsSent = 1;
+    HK_AppData.PacketNotFoundCtr   = 1;
     HK_AppData.MissingDataCtr      = 1;
 
     /* Act */
@@ -1064,6 +1067,7 @@ void Test_HK_ResetHkData(void)
     UtAssert_INT32_EQ(HK_AppData.CmdCounter, 0);
     UtAssert_INT32_EQ(HK_AppData.ErrCounter, 0);
     UtAssert_INT32_EQ(HK_AppData.CombinedPacketsSent, 0);
+    UtAssert_INT32_EQ(HK_AppData.PacketNotFoundCtr, 0);
     UtAssert_INT32_EQ(HK_AppData.MissingDataCtr, 0);
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));

--- a/unit-test/hk_utils_tests.c
+++ b/unit-test/hk_utils_tests.c
@@ -1047,6 +1047,7 @@ void Test_HK_SendCombinedHkPacket_NoMissingData(void)
 
     /* Assert */
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 0);
+    UtAssert_INT32_EQ(HK_AppData.PacketNotFoundCtr, 0);
     UtAssert_INT32_EQ(HK_AppData.MissingDataCtr, 0);
     UtAssert_INT32_EQ(call_count_CFE_SB_TimeStampMsg, 1);
     UtAssert_INT32_EQ(call_count_CFE_SB_TransmitMsg, 1);
@@ -1123,6 +1124,8 @@ void Test_HK_SendCombinedHkPacket_EmptyTable(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
+    UtAssert_INT32_EQ(HK_AppData.PacketNotFoundCtr, 1);
+
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_UNKNOWN_COMBINED_PACKET_EID);
@@ -1172,6 +1175,8 @@ void Test_HK_SendCombinedHkPacket_PacketNotFound(void)
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     /* Assert */
+    UtAssert_INT32_EQ(HK_AppData.PacketNotFoundCtr, 1);
+
     UtAssert_INT32_EQ(call_count_CFE_EVS_SendEvent, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_UNKNOWN_COMBINED_PACKET_EID);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #4
  - Adds a new struct member (`PacketNotFoundCtr`) to `HK_HkTlm_Payload_t` and `HK_AppData_t` that tracks the number of times a packet was not found during traversal of the copy table in `HK_SendCombinedHkPacket()`.
  - Split the `MissingDataCtr` in half to create this counter, but could also just utilize the padding that is already there for this new member, and keep both sized at `uint16` if needed

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
Additional information tracking number of times packet not found available in tlm packets now.

**Contributor Info**
Avi Weiss @thnkslprpt