### PR TITLE
Fix #58, add memset for uninitialized local

### DIFF
--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -1016,6 +1016,8 @@ void Test_HK_ResetCountersCmd(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "HK Reset Counters command received");
 
+    memset(&Buf, 0, sizeof(Buf));
+
     /* Act */
     HK_ResetCountersCmd(&Buf);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HK/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This variable is not actually read by the function under test, but memset to 0 squelches a warning about it.

Fixes #58

**Testing performed**
Build and run tests

**Expected behavior changes**
No behavior change, just gets rid of (false positive) compiler warning.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
