### PR TITLE
Fix #66, Update Reset Counters event type to INFO

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,14 +3,14 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:
     name: Codeql Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
     with:
-      component-path: apps/hk 
+      component-path: apps/hk
       prep: 'make prep; make -C build/tools/elf2cfetbl'
       make: 'make -C build/native/default_cpu1/apps/hk'
       setup: |

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/docs/dox_src/cfs_hk.dox
+++ b/docs/dox_src/cfs_hk.dox
@@ -54,7 +54,7 @@
 
   This document provides a complete specification for the commands and telemetry associated
   with the CFS Housekeeping (HK) application software.  The document is intended primarily
-  for users of the software (operations personal, test engineers, and maintenance personnel).
+  for users of the software (operations personnel, test engineers, and maintenance personnel).
   The last section of the document, the deployment guide section, is intended for mission
   developers when deploying and configuring the FM application software for a mission
   flight software build environment.

--- a/fsw/inc/hk_events.h
+++ b/fsw/inc/hk_events.h
@@ -81,7 +81,7 @@
 /**
  * \brief HK Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *

--- a/fsw/inc/hk_extern_typedefs.h
+++ b/fsw/inc/hk_extern_typedefs.h
@@ -33,7 +33,7 @@
  *       Dictates the number of elements in the hk copy table.
  *
  *  \par Limits
- *       The maximum size of this paramater is 8192
+ *       The maximum size of this parameter is 8192
  */
 #define HK_COPY_TABLE_ENTRIES 128
 

--- a/fsw/inc/hk_platform_cfg.h
+++ b/fsw/inc/hk_platform_cfg.h
@@ -38,7 +38,7 @@
  *  \par Limits
  *       The minimum size of this parameter is 1
  *       The maximum size dictated by cFE platform configuration
- *       parameter  CFE_SB_MAX_PIPE_DEPTH
+ *       parameter  OS_QUEUE_MAX_DEPTH
  */
 #define HK_PIPE_DEPTH 40
 

--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -360,7 +360,7 @@ void HK_NoopCmd(const CFE_SB_Buffer_t *BufPtr)
 void HK_ResetCountersCmd(const CFE_SB_Buffer_t *BufPtr)
 {
     HK_ResetHkData();
-    CFE_EVS_SendEvent(HK_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "HK Reset Counters command received");
+    CFE_EVS_SendEvent(HK_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "HK Reset Counters command received");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/hk_dispatch.c
+++ b/fsw/src/hk_dispatch.c
@@ -66,7 +66,7 @@ int32 HK_VerifyCmdLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Verify Non-Command Msg Length (Event is differnt)               */
+/* Verify Non-Command Msg Length (Event is different)               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 HK_VerifyMsgLength(const CFE_SB_Buffer_t *BufPtr, size_t ExpectedLength)

--- a/fsw/src/hk_verify.h
+++ b/fsw/src/hk_verify.h
@@ -43,10 +43,10 @@
 #endif
 /*
  * JPH 2015-06-29 - Removed check of:
- *  HK_PIPE_DEPTH  >  CFE_SB_MAX_PIPE_DEPTH
+ *  HK_PIPE_DEPTH  >  OS_QUEUE_MAX_DEPTH
  *
  * This is not a valid check anymore, as the HK app does not have knowledge
- * of CFE_SB_MAX_PIPE_DEPTH.  But if the configuration violates this rule it will
+ * of OS_QUEUE_MAX_DEPTH.  But if the configuration violates this rule it will
  * show up as an obvious run-time error so the compile-time check is redundant.
  */
 

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -50,7 +50,7 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function under test: HK_AppMain
  *
  * Case: Tests the "nominal" mode where all dependent calls should be
- *       successful by defaut.
+ *       successful by default.
  */
 void Test_HK_AppMain_Success(void)
 {
@@ -1028,7 +1028,7 @@ void Test_HK_ResetCountersCmd(void)
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, HK_RESET_INF_EID);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 

--- a/unit-test/hk_utils_tests.c
+++ b/unit-test/hk_utils_tests.c
@@ -1950,7 +1950,7 @@ void UtTest_Setup(void)
     UtTest_Add(Test_HK_ProcessIncomingHkData_MessageError, HK_Test_Setup, HK_Test_TearDown,
                "Test_HK_ProcessIncomingHkData_MessageError");
 
-    /* Test functions for HK_VaidateHkCopyTable */
+    /* Test functions for HK_ValidateHkCopyTable */
     UtTest_Add(Test_HK_ValidateHkCopyTable_Success, HK_Test_Setup, HK_Test_TearDown,
                "Test_HK_ValidateHkCopyTable_Success");
     UtTest_Add(Test_HK_ValidateHkCopyTable_Error, HK_Test_Setup, HK_Test_TearDown, "Test_HK_ValidateHkCopyTable_Error");


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #66 
  - Updates Reset Counters command event type to `INFORMATION`
  - A few typos fixed as well and references to `CFE_SB_MAX_PIPE_DEPTH` replaced with `OS_QUEUE_MAX_DEPTH`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Reset Counters command event will be `INFORMATION`, aligning HK with the cFS standard.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt