### PR TITLE
Fixed unit-test/hk_utils_tests.c for the address-sanitizer

### DIFF
--- a/unit-test/hk_utils_tests.c
+++ b/unit-test/hk_utils_tests.c
@@ -131,7 +131,7 @@ void Test_HK_ProcessIncomingHkData_LengthOkEqual(void)
     HK_Test_InitGoodCopyTable(CopyTblPtr);
     HK_Test_InitGoodRuntimeTable(RtTblPtr);
 
-    RtTblPtr[2].OutputPktAddr = OutputPkt;
+    RtTblPtr[2].OutputPktAddr = (CFE_SB_Buffer_t*)OutputPkt;
 
     HK_AppData.CopyTablePtr    = CopyTblPtr;
     HK_AppData.RuntimeTablePtr = RtTblPtr;
@@ -189,7 +189,7 @@ void Test_HK_ProcessIncomingHkData_LengthOkGreater(void)
     HK_Test_InitGoodCopyTable(CopyTblPtr);
     HK_Test_InitGoodRuntimeTable(RtTblPtr);
 
-    RtTblPtr[2].OutputPktAddr = OutputPkt;
+    RtTblPtr[2].OutputPktAddr = (CFE_SB_Buffer_t*)OutputPkt;
 
     HK_AppData.CopyTablePtr    = CopyTblPtr;
     HK_AppData.RuntimeTablePtr = RtTblPtr;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HK/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #71 
  - In `Test_HK_ProcessIncomingHkData_LengthOkEqual(void)` and void `Test_HK_ProcessIncomingHkData_LengthOkGreater(void)`, changed type of `OutputPkt` to an array of 100 unsigned bytes

**Testing performed**
Steps taken to test the contribution:
1. Unit tests passed with address sanitizer enabled

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - Unit tests will now pass when address-sanitizer is enabled

**System(s) tested on**
 - OS: Ubuntu 20.04.6
