### PR TITLE
Fix #73, Make implicit padding in `HK_AppData_t` explicit

### DIFF
--- a/fsw/inc/hk_extern_typedefs.h
+++ b/fsw/inc/hk_extern_typedefs.h
@@ -1,6 +1,6 @@
 /************************************************************************
- * NASA Docket No. GSC-18,447-1, and identified as “CFS CFDP (CF)
- * Application version 3.0.0”
+ * NASA Docket No. GSC-18,919-1, and identified as “Core Flight
+ * System (cFS) Housekeeping (HK) Application version 2.5.1”
  *
  * Copyright (c) 2019 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.

--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -103,10 +103,10 @@ void HK_AppMain(void)
         else
         {
             CFE_EVS_SendEvent(HK_RCV_MSG_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "HK_APP Exiting due to CFE_SB_RcvMsg error 0x%08X", (unsigned int)Status);
+                              "HK_APP Exiting due to CFE_SB_ReceiveBuffer error 0x%08X", (unsigned int)Status);
 
             /* Write to syslog in case there is a problem with event services */
-            CFE_ES_WriteToSysLog("HK_APP Exiting due to CFE_SB_RcvMsg error 0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("HK_APP Exiting due to CFE_SB_ReceiveBuffer error 0x%08X\n", (unsigned int)Status);
 
             HK_AppData.RunStatus = CFE_ES_RunStatus_APP_ERROR;
         }

--- a/fsw/src/hk_app.h
+++ b/fsw/src/hk_app.h
@@ -67,6 +67,7 @@ typedef struct
     CFE_SB_PipeId_t CmdPipe;    /**< \brief Pipe Id for HK command pipe */
     uint8           CmdCounter; /**< \brief Number of valid commands received */
     uint8           ErrCounter; /**< \brief Number of invalid commands received */
+    uint16          Padding;    /**< \brief Padding for structure alignment */
 
     uint16 MissingDataCtr;      /**< \brief Number of times missing data was detected */
     uint16 CombinedPacketsSent; /**< \brief Count of combined output msgs sent */
@@ -77,7 +78,7 @@ typedef struct
     CFE_TBL_Handle_t CopyTableHandle;    /**< \brief Copy Table handle */
     CFE_TBL_Handle_t RuntimeTableHandle; /**< \brief Run-time table handle */
 
-    hk_copy_table_entry_t * CopyTablePtr;    /**< \brief Ptr to copy table entry */
+    hk_copy_table_entry_t  *CopyTablePtr;    /**< \brief Ptr to copy table entry */
     hk_runtime_tbl_entry_t *RuntimeTablePtr; /**< \brief Ptr to run-time table entry */
 
     uint8 MemPoolBuffer[HK_NUM_BYTES_IN_MEM_POOL]; /**< \brief HK mempool buffer */

--- a/unit-test/hk_app_tests.c
+++ b/unit-test/hk_app_tests.c
@@ -150,7 +150,7 @@ void Test_HK_AppMain_RcvBufFail(void)
     int32 strCmpResult;
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "HK_APP Exiting due to CFE_SB_RcvMsg error 0x%%08X");
+             "HK_APP Exiting due to CFE_SB_ReceiveBuffer error 0x%%08X");
 
     /* Set return codes for table functions so that HK_TableInit
      * succeeds. */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #240 
  - Adds some spare bytes (to align to 32-byte boundary) to make the implicit (compiler-added) padding after `ErrCounter` explicit (it was probably added after `CombinedPacketsSent` but I think putting the padding here might be more logical - either position is fine).

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Avoids risk of size mismatch if decoding/encoding etc.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt