### PR TITLE
Fix #75, correct reversed `HK_DATA_PRESENT` comments

### DIFF
--- a/fsw/src/hk_utils.h
+++ b/fsw/src/hk_utils.h
@@ -36,8 +36,8 @@
 #define HK_INPUTMID_SUBSCRIBED     (0xFF) /**< \brief Input MsgId has been subscribed to */
 #define HK_INPUTMID_NOT_SUBSCRIBED (0)    /**< \brief Input MsgId is not subscribed */
 
-#define HK_DATA_NOT_PRESENT (0) /**< \brief Input MsgId present in output msg */
-#define HK_DATA_PRESENT     (1) /**< \brief Input MsgId not present */
+#define HK_DATA_NOT_PRESENT (0) /**< \brief Input MsgId data not present in output msg */
+#define HK_DATA_PRESENT     (1) /**< \brief Input MsgId data present in output msg */
 
 #define HK_NO_MISSING_DATA       (0) /**< \brief Output Msg has no missing data */
 #define HK_MISSING_DATA_DETECTED (1) /**< \brief Output Msg has missing data */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #75 

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Comment changes only.  
Reduces potential for confusion by users.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt