### PR TITLE
Fix #53, align `PerfLogEntry` point to cFS pattern (immediately after `ReceiveBuffer`)

### DIFF
--- a/fsw/src/hk_app.c
+++ b/fsw/src/hk_app.c
@@ -79,13 +79,13 @@ void HK_AppMain(void)
         */
         Status = CFE_SB_ReceiveBuffer(&BufPtr, HK_AppData.CmdPipe, HK_SB_TIMEOUT);
 
+        /*
+        ** Performance Log Entry Stamp.
+        */
+        CFE_ES_PerfLogEntry(HK_APPMAIN_PERF_ID);
+
         if (Status == CFE_SUCCESS)
         {
-            /*
-            ** Performance Log Entry Stamp.
-            */
-            CFE_ES_PerfLogEntry(HK_APPMAIN_PERF_ID);
-
             /* Perform Message Processing */
             HK_AppPipe(BufPtr);
         }
@@ -131,6 +131,9 @@ void HK_AppMain(void)
 CFE_Status_t HK_AppInit(void)
 {
     CFE_Status_t Status = CFE_SUCCESS;
+
+    /* Initialize (zero-out) the global data structure */
+    memset(&HK_AppData, 0, sizeof(HK_AppData));
 
     HK_AppData.RunStatus = CFE_ES_RunStatus_APP_RUN;
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #53
- also added total `memset` of app data at beginning of init for clarity and safety-sake

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Log correct/expected span and align with cFS norms.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt