### PR TITLE
ci: declare workflow-level `contents: read` on check workflows

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codeql:
     name: Codeql Analysis

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -14,6 +14,9 @@ on:
   workflow_dispatch:
 
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: Run format check

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     name: Static Analysis


### PR DESCRIPTION
Adds workflow-level `permissions: contents: read` to the check workflows in this repo (format-check, codeql-build, static-analysis where present). All run pure code checks; jobs that need higher scope can still override at job level.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.